### PR TITLE
Add server configuration information to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,3 +185,14 @@ protected function createAuthenticatedClient($username = 'user@acme.tld')
     return $client;
 }
 ```
+
+### Server configuration
+
+Required by Symfony 2.3 or newer.
+
+Add the following lines to the `.htaccess` right after `RewriteEngine On`:
+
+```
+    RewriteCond %{HTTP:Authorization} ^(.*)
+    RewriteRule .* - [e=HTTP_Authorization:%1]
+```


### PR DESCRIPTION
Symfony 2.3 or newer won't pick the `Authorisation: Bearer ...` by default - update to `.htaccess` or virtual host definition is required. See http://stackoverflow.com/questions/19443718/symfony-2-3-getrequest-headers-not-showing-authorization-bearer-token/19445020#19445020
