### PR TITLE
Improve json 401 exception

### DIFF
--- a/Security/Http/EntryPoint/JWTEntryPoint.php
+++ b/Security/Http/EntryPoint/JWTEntryPoint.php
@@ -19,6 +19,13 @@ class JWTEntryPoint implements AuthenticationEntryPointInterface
      */
     public function start(Request $request, AuthenticationException $authException = null)
     {
-        return new JsonResponse('invalid credentials', 401);
+        $statusCode = 401;
+
+        $data = array(
+            'code' => $statusCode,
+            'message' => 'Invalid credentials',
+        );
+
+        return new JsonResponse($data, $statusCode);
     }
 }

--- a/Tests/Security/Http/EntryPoint/JWTEntryPointTest.php
+++ b/Tests/Security/Http/EntryPoint/JWTEntryPointTest.php
@@ -21,6 +21,10 @@ class JWTEntryPointTest extends \PHPUnit_Framework_TestCase
         $response = $entryPoint->start($this->getRequest());
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertEquals(401, $response->getStatusCode(), 'status code should be 401');
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertEquals($data['code'], '401');
+        $this->assertEquals($data['message'], 'Invalid credentials');
     }
 
     /**


### PR DESCRIPTION
Returns an object with `code` and `message` fields instead of a string.
