### PR TITLE
Improve response and dispatch event in AuthenticationFailureHandler

### DIFF
--- a/Event/AuthenticationFailureEvent.php
+++ b/Event/AuthenticationFailureEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * AuthenticationFailureEvent
+ *
+ * @author Emmanuel Vella <vella.emmanuel@gmail.com>
+ */
+class AuthenticationFailureEvent extends GetResponseEvent
+{
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * @param Request $request
+     */
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+}

--- a/Events.php
+++ b/Events.php
@@ -16,6 +16,11 @@ final class Events
     const AUTHENTICATION_SUCCESS = 'lexik_jwt_authentication.on_authentication_success';
 
     /**
+     * Dispatched after an authentication failure
+     */
+    const AUTHENTICATION_FAILURE = 'lexik_jwt_authentication.on_authentication_failure';
+
+    /**
      * Dispatched before the token payload is encoded by the configured encoder (JWTEncoder by default).
      * Hook into this event to add extra fields to the payload.
      */

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -40,6 +40,7 @@
         </service>
         <service id="lexik_jwt_authentication.handler.authentication_failure" class="%lexik_jwt_authentication.handler.authentication_failure.class%">
             <tag name="monolog.logger" channel="security"></tag>
+            <argument type="service" id="event_dispatcher"/>
         </service>
         <!-- JWT Security Authentication Provider -->
         <service id="lexik_jwt_authentication.security.authentication.provider" class="%lexik_jwt_authentication.security.authentication.provider.class%" public="false">

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -2,6 +2,9 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication;
 
+use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationFailureEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -14,11 +17,32 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerI
  */
 class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterface
 {
+    protected $dispatcher;
+
+    public function __construct(EventDispatcherInterface $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
     /**
      * {@inheritDoc}
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        return new JsonResponse('Bad credentials', 401);
+        $statusCode = 401;
+
+        $data = array(
+            'code' => $statusCode,
+            'message' => 'Bad credentials',
+        );
+
+        $response = new JsonResponse($data, $statusCode);
+
+        $event = new AuthenticationFailureEvent($request);
+        $event->setResponse($response);
+
+        $this->dispatcher->dispatch(Events::AUTHENTICATION_FAILURE, $event);
+
+        return $event->getResponse();
     }
 }

--- a/Tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
+++ b/Tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
@@ -17,11 +17,16 @@ class AuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnAuthenticationFailure()
     {
-        $handler = new AuthenticationFailureHandler();
+        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+
+        $handler = new AuthenticationFailureHandler($dispatcher);
         $response = $handler->onAuthenticationFailure($this->getRequest(), $this->getAuthenticationException());
+        $content = json_decode($response->getContent(), true);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
         $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals(401, $content['code']);
+        $this->assertEquals('Bad credentials', $content['message']);
     }
 
     /**


### PR DESCRIPTION
Response status code is changed from `401 (Unauthorized)` to `400 (Bad Request)` (see http://stackoverflow.com/a/1960453). I think this makes more sense if the login parameters are invalid.

Response is now a valid json object containing a `code` and a `message` attributes.

The handler now dispatch a failure event.
