### PR TITLE
Removed deprecated SecurityContext in favour of TokenStorage for Symfony 2.6

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -55,7 +55,7 @@
         </service>
         <!-- JWT Security Authentication Listener -->
         <service id="lexik_jwt_authentication.security.authentication.listener" class="%lexik_jwt_authentication.security.authentication.listener.class%" public="false">
-            <argument type="service" id="security.context"/>
+            <argument type="service" id="security.token_storage"/>
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Options -->
         </service>

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 
 /**
@@ -22,7 +22,7 @@ class JWTListener implements ListenerInterface
     /**
      * @var SecurityContextInterface
      */
-    protected $securityContext;
+    protected $tokenStorage;
 
     /**
      * @var AuthenticationManagerInterface
@@ -40,13 +40,13 @@ class JWTListener implements ListenerInterface
     protected $tokenExtractors;
 
     /**
-     * @param SecurityContextInterface       $securityContext
+     * @param TokenStorageIterface           $tokenStorage
      * @param AuthenticationManagerInterface $authenticationManager
      * @param array                          $config
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, array $config = array())
+    public function __construct(TokenStorageInterface  $tokenStorage, AuthenticationManagerInterface $authenticationManager, array $config = array())
     {
-        $this->securityContext       = $securityContext;
+        $this->tokenStorage          = $tokenStorage;
         $this->authenticationManager = $authenticationManager;
         $this->config                = array_merge(array('throw_exceptions' => false), $config);
         $this->tokenExtractors       = array();
@@ -67,7 +67,7 @@ class JWTListener implements ListenerInterface
         try {
 
             $authToken = $this->authenticationManager->authenticate($token);
-            $this->securityContext->setToken($authToken);
+            $this->tokenStorage->setToken($authToken);
 
             return;
 

--- a/Tests/Security/Authentication/Firewall/JWTListenerTest.php
+++ b/Tests/Security/Authentication/Firewall/JWTListenerTest.php
@@ -18,12 +18,12 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
     {
         // no token extractor : should return void
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $this->getAuthenticationManagerMock());
+        $listener = new JWTListener($this->getTokenStorageMock(), $this->getAuthenticationManagerMock());
         $this->assertNull($listener->handle($this->getEvent()));
 
         // one token extractor with no result : should return void
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $this->getAuthenticationManagerMock());
+        $listener = new JWTListener($this->getTokenStorageMock(), $this->getAuthenticationManagerMock());
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock(false));
         $this->assertNull($listener->handle($this->getEvent()));
 
@@ -32,7 +32,7 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
         $authenticationManager = $this->getAuthenticationManagerMock();
         $authenticationManager->expects($this->once())->method('authenticate');
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $authenticationManager);
+        $listener = new JWTListener($this->getTokenStorageMock(), $authenticationManager);
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock('token'));
         $listener->handle($this->getEvent());
 
@@ -47,7 +47,7 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
             ->method('authenticate')
             ->will($this->throwException(new \Symfony\Component\Security\Core\Exception\AuthenticationException()));
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $authenticationManager);
+        $listener = new JWTListener($this->getTokenStorageMock(), $authenticationManager);
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock('token'));
 
         $event = $this->getEvent();
@@ -70,10 +70,10 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    public function getSecurityContextMock()
+    public function getTokenStorageMock()
     {
         return $this
-            ->getMockBuilder('Symfony\Component\Security\Core\SecurityContext')
+            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage')
             ->disableOriginalConstructor()
             ->getMock();
     }


### PR DESCRIPTION
This PR provides support for Symfony >= 2.6
If accepted, this must be tagged to not BC Symfony < 2.6

