### PR TITLE
fixed deprecated errors for symfony 2.6 plus

### DIFF
--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -36,6 +36,19 @@ class LexikJWTAuthenticationExtension extends Extension
         $container->setParameter('lexik_jwt_authentication.user_identity_field', $config['user_identity_field']);
 
         $container->setAlias('lexik_jwt_authentication.encoder', $config['encoder_service']);
+
+        // thanks https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/DependencyInjection/FOSUserExtension.php
+
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $tokenStorageReference = new Reference('security.token_storage');
+        } else {
+            $tokenStorageReference = new Reference('security.context');
+        }
+
+        $container
+            ->getDefinition('lexik_jwt_authentication.security.authentication.listener')
+            ->replaceArgument(0, $tokenStorageReference)
+        ;
     }
 
     /**

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -55,7 +55,7 @@
         </service>
         <!-- JWT Security Authentication Listener -->
         <service id="lexik_jwt_authentication.security.authentication.listener" class="%lexik_jwt_authentication.security.authentication.listener.class%" public="false">
-            <argument type="service" id="security.context"/>
+            <argument /> <!-- security.token_storage or security.context for Symfony <2.6 -->
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Options -->
         </service>

--- a/Tests/Security/Authentication/Firewall/JWTListenerTest.php
+++ b/Tests/Security/Authentication/Firewall/JWTListenerTest.php
@@ -18,12 +18,12 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
     {
         // no token extractor : should return void
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $this->getAuthenticationManagerMock());
+        $listener = new JWTListener($this->getTokenStorageMock(), $this->getAuthenticationManagerMock());
         $this->assertNull($listener->handle($this->getEvent()));
 
         // one token extractor with no result : should return void
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $this->getAuthenticationManagerMock());
+        $listener = new JWTListener($this->getTokenStorageMock(), $this->getAuthenticationManagerMock());
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock(false));
         $this->assertNull($listener->handle($this->getEvent()));
 
@@ -32,7 +32,7 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
         $authenticationManager = $this->getAuthenticationManagerMock();
         $authenticationManager->expects($this->once())->method('authenticate');
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $authenticationManager);
+        $listener = new JWTListener($this->getTokenStorageMock(), $authenticationManager);
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock('token'));
         $listener->handle($this->getEvent());
 
@@ -47,7 +47,7 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
             ->method('authenticate')
             ->will($this->throwException(new \Symfony\Component\Security\Core\Exception\AuthenticationException()));
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $authenticationManager);
+        $listener = new JWTListener($this->getTokenStorageMock(), $authenticationManager);
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock('token'));
 
         $event = $this->getEvent();
@@ -70,10 +70,16 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    public function getSecurityContextMock()
+    public function getTokenStorageMock()
     {
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $class = 'Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface';
+        } else {
+            $class = 'Symfony\Component\Security\Core\SecurityContext';
+        }
+
         return $this
-            ->getMockBuilder('Symfony\Component\Security\Core\SecurityContext')
+            ->getMockBuilder($class)
             ->disableOriginalConstructor()
             ->getMock();
     }


### PR DESCRIPTION
Fix deprecated warnings and errors during tests for symfony 2.6+.
Used same logic as in FOSUserBundle to handle both SecurityContextInterface and TokenStorageInterface.