### PR TITLE
Fixing a missing use statement for Reference

### DIFF
--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -4,6 +4,7 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 


### PR DESCRIPTION
* Use statement was preventing the bundle from properly working
PHP Fatal error:  Class 'Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Reference' not found in /vagrant/vendor/lexik/jwt-authentication-bundle/Lexik/Bundle/JWTAuthenticationBundle/DependencyInjection/LexikJWTAuthenticationExtension.php on line 43