### PR TITLE
add JWTEncodedEvent so JWT string is available after its creation

### DIFF
--- a/Event/JWTEncodedEvent.php
+++ b/Event/JWTEncodedEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class JWTEncodedEvent
+ * @package Lexik\Bundle\JWTAuthenticationBundle\Event
+ */
+class JWTEncodedEvent extends Event
+{
+
+    /**
+     * @var $jwtString
+     */
+    private $jwtString;
+
+    /**
+     * @param $jwtString
+     */
+    public function __construct($jwtString)
+    {
+        $this->jwtString = $jwtString;
+    }
+
+    /**
+     * @return $jwtString
+     */
+    public function getJWTString()
+    {
+        return $this->jwtString;
+    }
+}

--- a/Events.php
+++ b/Events.php
@@ -27,6 +27,12 @@ final class Events
     const JWT_CREATED = 'lexik_jwt_authentication.on_jwt_created';
 
     /**
+     * Dispatched right after token string is created.
+     * Hook into this event to get token representation itself.
+     */
+    const JWT_ENCODED = 'lexik_jwt_authentication.on_jwt_encoded';
+
+    /**
      * Dispatched after the token payload has been decoded by the configured encoder (JWTEncoder by default).
      * Hook into this event to perform additional validation on the received payload.
      */

--- a/Resources/doc/2-data-customization.md
+++ b/Resources/doc/2-data-customization.md
@@ -178,3 +178,20 @@ public function onAuthenticationSuccessResponse(AuthenticationSuccessEvent $even
     $event->setData($data);
 }
 ```
+#### Events::JWT_ENCODED - get JWT string
+
+You may need to get JWT after its creation.
+
+Example 6: obtain JWT string
+
+``` php
+// Acme\Bundle\ApiBundle\EventListener\OnJwtEncoded.php
+
+/**
+ * @param JWTEncodedEvent $event
+ */
+public function onJwtEncoded(JWTEncodedEvent $event)
+{
+    $token = $event->getJWTString();
+}
+```

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -5,12 +5,14 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Services;
 use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTDecodedEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+
 /**
  * JWTManager
  *
@@ -67,10 +69,15 @@ class JWTManager implements JWTManagerInterface
 
         $this->addUserIdentityToPayload($user, $payload);
 
-        $event = new JWTCreatedEvent($payload, $user, $this->request);
-        $this->dispatcher->dispatch(Events::JWT_CREATED, $event);
+        $jwtCreatedEvent = new JWTCreatedEvent($payload, $user, $this->request);
+        $this->dispatcher->dispatch(Events::JWT_CREATED, $jwtCreatedEvent);
 
-        return $this->jwtEncoder->encode($event->getData());
+        $jwtString = $this->jwtEncoder->encode($jwtCreatedEvent->getData());
+
+        $jwtEncodedEvent = new JWTEncodedEvent($jwtString);
+        $this->dispatcher->dispatch(Events::JWT_ENCODED, $jwtEncodedEvent);
+
+        return $jwtString;
     }
 
     /**

--- a/Tests/Services/JWTManagerTest.php
+++ b/Tests/Services/JWTManagerTest.php
@@ -21,11 +21,19 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
     {
         $dispatcher = $this->getEventDispatcherMock();
         $dispatcher
-            ->expects($this->once())
+            ->expects($this->at(0))
             ->method('dispatch')
             ->with(
                 $this->equalTo(Events::JWT_CREATED),
                 $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent')
+            );
+
+        $dispatcher
+            ->expects($this->at(1))
+            ->method('dispatch')
+            ->with(
+                $this->equalTo(Events::JWT_ENCODED),
+                $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent')
             );
 
         $encoder = $this->getJWTEncoderMock();
@@ -70,11 +78,19 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
         
         $dispatcher = $this->getEventDispatcherMock();
         $dispatcher
-            ->expects($this->once())
+            ->expects($this->at(0))
             ->method('dispatch')
             ->with(
                 $this->equalTo(Events::JWT_CREATED),
                 $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent')
+            );
+
+        $dispatcher
+            ->expects($this->at(1))
+            ->method('dispatch')
+            ->with(
+                $this->equalTo(Events::JWT_ENCODED),
+                $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent')
             );
 
         $encoder = $this->getJWTEncoderMock();


### PR DESCRIPTION
Sometimes this is useful (or even essential) to get JWT string right after it is created. This PR introduces new type of event - JWTEncodedEvent which is being dispatched right after JWT is created (encoded) and contains JWT string.