### PR TITLE
Add cookie token extractor

### DIFF
--- a/DependencyInjection/Security/Factory/JWTFactory.php
+++ b/DependencyInjection/Security/Factory/JWTFactory.php
@@ -62,6 +62,19 @@ class JWTFactory implements SecurityFactoryInterface
 
         }
 
+        if ($config['cookie']['enabled']) {
+
+            $cookieExtractorId = 'lexik_jwt_authentication.extractor.cookie_extractor.' . $id;
+            $container
+                ->setDefinition($cookieExtractorId, new DefinitionDecorator('lexik_jwt_authentication.extractor.cookie_extractor'))
+                ->replaceArgument(0, $config['cookie']['name']);
+
+            $container
+                ->getDefinition($listenerId)
+                ->addMethodCall('addTokenExtractor', array(new Reference($cookieExtractorId)));
+
+        }
+
         return array($providerId, $listenerId, $entryPointId);
     }
 
@@ -96,6 +109,17 @@ class JWTFactory implements SecurityFactoryInterface
                         ->end()
                         ->scalarNode('prefix')
                             ->defaultValue('Bearer')
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('cookie')
+                ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')
+                            ->defaultFalse()
+                        ->end()
+                        ->scalarNode('name')
+                            ->defaultValue('BEARER')
                         ->end()
                     ->end()
                 ->end()

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,6 +14,7 @@
         <parameter key="lexik_jwt_authentication.security.authentication.entry_point.class">Lexik\Bundle\JWTAuthenticationBundle\Security\Http\EntryPoint\JWTEntryPoint</parameter>
         <parameter key="lexik_jwt_authentication.extractor.authorization_header_extractor.class">Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\AuthorizationHeaderTokenExtractor</parameter>
         <parameter key="lexik_jwt_authentication.extractor.query_parameter_extractor.class">Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\QueryParameterTokenExtractor</parameter>
+        <parameter key="lexik_jwt_authentication.extractor.cookie_extractor.class">Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\CookieTokenExtractor</parameter>
     </parameters>
 
     <services>
@@ -67,6 +68,10 @@
         <!-- Query Parameter Token Extractor -->
         <service id="lexik_jwt_authentication.extractor.query_parameter_extractor" class="%lexik_jwt_authentication.extractor.query_parameter_extractor.class%" public="false">
             <argument /> <!-- Parameter Name -->
+        </service>
+        <!-- Cookie Token Extractor -->
+        <service id="lexik_jwt_authentication.extractor.cookie_extractor" class="%lexik_jwt_authentication.extractor.cookie_extractor.class%" public="false">
+            <argument /> <!-- Name -->
         </service>
         <!-- JWT Security Authentication Entry Point -->
         <service id="lexik_jwt_authentication.security.authentication.entry_point" class="%lexik_jwt_authentication.security.authentication.entry_point.class%" public="false"></service>

--- a/Resources/doc/1-configuration-reference.md
+++ b/Resources/doc/1-configuration-reference.md
@@ -43,8 +43,11 @@ firewalls:
             authorization_header: # check token in Authorization Header
                 enabled: true
                 prefix:  Bearer
+            cookie:               # check token in a cookie
+                enabled: false
+                name:    BEARER
             query_parameter:      # check token in query string parameter
-                enabled: true
+                enabled: false
                 name:    bearer
             throw_exceptions:        false     # When an authentication failure occurs, return a 401 response immediately
             create_entry_point:      true      # When no authentication details are provided, create a default entry point that returns a 401 response

--- a/Tests/TokenExtractor/CookieTokenExtractorTest.php
+++ b/Tests/TokenExtractor/CookieTokenExtractorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\TokenExtractor;
+
+use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\CookieTokenExtractor;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * CookieTokenExtractorTest
+ *
+ * @author Nicolas Cabot <n.cabot@lexik.fr>
+ */
+class CookieTokenExtractorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * test getRequestToken
+     */
+    public function testGetTokenRequest()
+    {
+        $extractor = new CookieTokenExtractor('BEARER');
+
+        $request = new Request();
+        $this->assertFalse($extractor->extract($request));
+
+        $request = new Request();
+        $request->cookies->add(array('BEAR' => 'testtoken'));
+        $this->assertFalse($extractor->extract($request));
+
+        $request = new Request();
+        $request->cookies->add(array('BEARER' => 'testtoken'));
+        $this->assertEquals('testtoken', $extractor->extract($request));
+    }
+}

--- a/TokenExtractor/CookieTokenExtractor.php
+++ b/TokenExtractor/CookieTokenExtractor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * CookieTokenExtractor
+ *
+ * @author Nicolas Cabot <n.cabot@lexik.fr>
+ */
+class CookieTokenExtractor implements TokenExtractorInterface
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @param string $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @param Request $request
+     * @return string
+     */
+    public function extract(Request $request)
+    {
+        if (!$request->cookies->has($this->name)) {
+            return false;
+        }
+
+        return $request->cookies->get($this->name);
+    }
+}


### PR DESCRIPTION
Hi,

We store the token in a cookie (secure and httponly) in onAuthenticationSuccess like this :
<pre>
    public function onAuthenticationSuccess(Request $request, TokenInterface $token)
    {
        $response = parent::onAuthenticationSuccess($request, $token);

        $tokenJWT = json_decode($response->getContent(), true)['token'];

        // Ajoute le token avec l'id de l'utilisateur en clé dans les Redis configurés, avec le ttl contenu dans la conf
        $this->rms->set($this->redisDB, $token->getUser()->getId(), $tokenJWT, $this->jwtTokenTTL);

        // Crée le cookie contenant le token, avec le ttl contenu dans la conf
        $response->headers->setCookie(new Cookie('CERBERE', $tokenJWT, (new \DateTime())->add(new \DateInterval('PT' . $this->jwtTokenTTL . 'S')), '/', null, $this->cookieSecure));

        return $response;
    }
</pre>

Cookie is send transparently from Front to Back.
So we need a cookie token extractor.

Thanks
