### PR TITLE
Fix authentication event propagation

### DIFF
--- a/Event/AuthenticationFailureEvent.php
+++ b/Event/AuthenticationFailureEvent.php
@@ -2,8 +2,9 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
 
+use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
@@ -11,7 +12,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  *
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
  */
-class AuthenticationFailureEvent extends GetResponseEvent
+class AuthenticationFailureEvent extends Event
 {
     /**
      * @var Request
@@ -24,12 +25,20 @@ class AuthenticationFailureEvent extends GetResponseEvent
     protected $exception;
 
     /**
-     * @param Request $request
+     * @var Response
      */
-    public function __construct(Request $request, AuthenticationException $exception)
+    protected $response;
+
+    /**
+     * @param Request                 $request
+     * @param AuthenticationException $exception
+     * @param Response                $response
+     */
+    public function __construct(Request $request, AuthenticationException $exception, Response $response)
     {
         $this->request = $request;
         $this->exception = $exception;
+        $this->response = $response;
     }
 
     /**
@@ -46,5 +55,13 @@ class AuthenticationFailureEvent extends GetResponseEvent
     public function getException()
     {
         return $this->exception;
+    }
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
     }
 }

--- a/Event/AuthenticationSuccessEvent.php
+++ b/Event/AuthenticationSuccessEvent.php
@@ -3,8 +3,9 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
 
+use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -12,7 +13,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  *
  * @author Dev Lexik <dev@lexik.fr>
  */
-class AuthenticationSuccessEvent extends GetResponseEvent
+class AuthenticationSuccessEvent extends Event
 {
     /**
      * @var array
@@ -30,15 +31,22 @@ class AuthenticationSuccessEvent extends GetResponseEvent
     protected $request;
 
     /**
+     * @var Response
+     */
+    protected $response;
+
+    /**
      * @param array         $data
      * @param UserInterface $user
      * @param Request       $request
+     * @param Response      $response
      */
-    public function __construct(array $data, UserInterface $user, Request $request)
+    public function __construct(array $data, UserInterface $user, Request $request, Response $response)
     {
-        $this->data    = $data;
-        $this->user    = $user;
+        $this->data = $data;
+        $this->user = $user;
         $this->request = $request;
+        $this->response = $response;
     }
 
     /**
@@ -73,5 +81,13 @@ class AuthenticationSuccessEvent extends GetResponseEvent
     public function getRequest()
     {
         return $this->request;
+    }
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
     }
 }

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -43,8 +43,8 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
             'message' => self::RESPONSE_MESSAGE,
         );
 
-        $event = new AuthenticationFailureEvent($request, $exception);
-        $event->setResponse(new JsonResponse($data, self::RESPONSE_CODE));
+        $response = new JsonResponse($data, self::RESPONSE_CODE);
+        $event = new AuthenticationFailureEvent($request, $exception, $response);
 
         $this->dispatcher->dispatch(Events::AUTHENTICATION_FAILURE, $event);
 

--- a/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -48,8 +48,7 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
 
         $response = new JsonResponse();
 
-        $event = new AuthenticationSuccessEvent(array('token' => $jwt), $user, $request);
-        $event->setResponse($response);
+        $event = new AuthenticationSuccessEvent(array('token' => $jwt), $user, $request, $response);
 
         $this->dispatcher->dispatch(Events::AUTHENTICATION_SUCCESS, $event);
 


### PR DESCRIPTION
This PR fixes https://github.com/lexik/LexikJWTAuthenticationBundle/issues/89 .

I've removed the `extends GetResponseEvent` from events : this parent event is bound to the kernel (see the [symfony api doc](http://api.symfony.com/2.7/Symfony/Component/HttpKernel/Event/GetResponseEvent.html)), and does not make sense here. Moreover, the [`GetResponseEvent::setResponse()`](https://github.com/lexik/LexikJWTAuthenticationBundle/blob/a0e2f0a0fafdd41ccdba1c368101c242f2463918/Security/Http/Authentication/AuthenticationSuccessHandler.php#L52) method does a `stopPropagation()` and prevents the use of more than one listener.