### PR TITLE
Add custom authorization header name

### DIFF
--- a/DependencyInjection/Security/Factory/JWTFactory.php
+++ b/DependencyInjection/Security/Factory/JWTFactory.php
@@ -41,7 +41,8 @@ class JWTFactory implements SecurityFactoryInterface
             $authorizationHeaderExtractorId = 'lexik_jwt_authentication.extractor.authorization_header_extractor.' . $id;
             $container
                 ->setDefinition($authorizationHeaderExtractorId, new DefinitionDecorator('lexik_jwt_authentication.extractor.authorization_header_extractor'))
-                ->replaceArgument(0, $config['authorization_header']['prefix']);
+                ->replaceArgument(0, $config['authorization_header']['prefix'])
+                ->replaceArgument(1, $config['authorization_header']['name']);
 
             $container
                 ->getDefinition($listenerId)
@@ -109,6 +110,9 @@ class JWTFactory implements SecurityFactoryInterface
                         ->end()
                         ->scalarNode('prefix')
                             ->defaultValue('Bearer')
+                        ->end()
+                        ->scalarNode('name')
+                            ->defaultValue('Authorization')
                         ->end()
                     ->end()
                 ->end()

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -64,6 +64,7 @@
         <!-- Authorization Header Token Extractor -->
         <service id="lexik_jwt_authentication.extractor.authorization_header_extractor" class="%lexik_jwt_authentication.extractor.authorization_header_extractor.class%" public="false">
             <argument /> <!-- Header Value Prefix -->
+            <argument /> <!-- Header Value Name -->
         </service>
         <!-- Query Parameter Token Extractor -->
         <service id="lexik_jwt_authentication.extractor.query_parameter_extractor" class="%lexik_jwt_authentication.extractor.query_parameter_extractor.class%" public="false">

--- a/Resources/doc/1-configuration-reference.md
+++ b/Resources/doc/1-configuration-reference.md
@@ -43,6 +43,7 @@ firewalls:
             authorization_header: # check token in Authorization Header
                 enabled: true
                 prefix:  Bearer
+                name:    Authorization
             cookie:               # check token in a cookie
                 enabled: false
                 name:    BEARER

--- a/Tests/TokenExtractor/AuthorizationHeaderTokenExtractorTest.php
+++ b/Tests/TokenExtractor/AuthorizationHeaderTokenExtractorTest.php
@@ -17,13 +17,17 @@ class AuthorizationHeaderTokenExtractorTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetTokenRequest()
     {
-        $extractor = new AuthorizationHeaderTokenExtractor('Bearer');
+        $extractor = new AuthorizationHeaderTokenExtractor('Bearer', 'Authorization');
 
         $request = new Request();
         $this->assertFalse($extractor->extract($request));
 
         $request = new Request();
         $request->headers->set('Authorization', 'Bear testtoken');
+        $this->assertFalse($extractor->extract($request));
+
+        $request = new Request();
+        $request->headers->set('Authorizat', 'Bearer testtoken');
         $this->assertFalse($extractor->extract($request));
 
         $request = new Request();

--- a/TokenExtractor/AuthorizationHeaderTokenExtractor.php
+++ b/TokenExtractor/AuthorizationHeaderTokenExtractor.php
@@ -17,11 +17,18 @@ class AuthorizationHeaderTokenExtractor implements TokenExtractorInterface
     protected $prefix;
 
     /**
-     * @param string $prefix
+     * @var string
      */
-    public function __construct($prefix)
+    protected $name;
+
+    /**
+     * @param string $prefix
+     * @param string $name
+     */
+    public function __construct($prefix, $name)
     {
         $this->prefix = $prefix;
+        $this->name = $name;
     }
 
     /**
@@ -31,11 +38,11 @@ class AuthorizationHeaderTokenExtractor implements TokenExtractorInterface
      */
     public function extract(Request $request)
     {
-        if (!$request->headers->has('Authorization')) {
+        if (!$request->headers->has($this->name)) {
             return false;
         }
 
-        $headerParts = explode(' ', $request->headers->get('Authorization'));
+        $headerParts = explode(' ', $request->headers->get($this->name));
 
         if (!(count($headerParts) === 2 && $headerParts[0] === $this->prefix)) {
             return false;


### PR DESCRIPTION
Hi, I need double authentication : HTTP basic for general restriction and JWT at API level.
They both used the same header (Authorization).
This PR allows to use a custom header name for JWT token in order to handle double authentication.