### PR TITLE
Fatal error on console cache:clear

### DIFF
--- a/DependencyInjection/Security/Factory/JWTFactory.php
+++ b/DependencyInjection/Security/Factory/JWTFactory.php
@@ -142,6 +142,7 @@ class JWTFactory implements SecurityFactoryInterface
                 ->end()
                 ->scalarNode('authentication_provider')
                     ->defaultValue('lexik_jwt_authentication.security.authentication.provider')
+                ->end()
                 ->scalarNode('authentication_listener')
                     ->defaultValue('lexik_jwt_authentication.security.authentication.listener')
                 ->end()


### PR DESCRIPTION
PHP Fatal error:  Call to undefined method Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition::scalarNode() in vendor/lexik/jwt-authentication-bundle/Lexik/Bundle/JWTAuthenticationBundle/DependencyInjection/Security/Factory/JWTFactory.php on line 145