### PR TITLE
Updated to newest namshi/jose. Dropped support for PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6

--- a/Encoder/JWTEncoder.php
+++ b/Encoder/JWTEncoder.php
@@ -2,7 +2,8 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Encoder;
 
-use Namshi\JOSE\JWS;
+use InvalidArgumentException;
+use Namshi\JOSE\SimpleJWS;
 
 /**
  * JWTEncoder
@@ -45,7 +46,7 @@ class JWTEncoder implements JWTEncoderInterface
      */
     public function encode(array $data)
     {
-        $jws = new JWS(self::ALGORYTHM);
+        $jws = new SimpleJWS(array('alg' => self::ALGORYTHM));
         $jws->setPayload($data);
         $jws->sign($this->getPrivateKey());
 
@@ -58,8 +59,8 @@ class JWTEncoder implements JWTEncoderInterface
     public function decode($token)
     {
         try {
-            $jws = JWS::load($token);
-        } catch (\InvalidArgumentException $e) {
+            $jws = SimpleJWS::load($token);
+        } catch (InvalidArgumentException $e) {
             return false;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.8",
         "symfony/symfony": "~2.3",
         "symfony/framework-bundle": "~2.3",
-        "namshi/jose": "~2.2"
+        "namshi/jose": "~6.0"
     },
     "suggest": {
         "gesdinet/jwt-refresh-token-bundle": "Implements a refresh token system over Json Web Tokens in Symfony"


### PR DESCRIPTION
Updated namsho version to allow newer phpseclib.

All of the phpunit tests passed, so I guess it's fine.

This drops the support of PHP 5.3, but I think it's worth it, as more and more libraries use phpseclib 2.0. This resolves conflicts eg with newest google API client library.