### PR TITLE
Symfony 3.0 support fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     "require": {
         "php": ">=5.4.8",
         "symfony/symfony": "~2.3|~3.0",
-        "symfony/framework-bundle": "~2.3",
         "namshi/jose": "~6.0"
     },
     "suggest": {


### PR DESCRIPTION
Hi, commit eacd6d1cb4d4f0a40f56857df6492f1183e9be15 has been overwritten by 90eeea3308403997ba753104065d90f2b7ef59f0, so that Symfony 3.0 is not supported in the current master branch. My commit fixes the problem.