### PR TITLE
Allow empty ttl

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,7 +36,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('token_ttl')
                     ->defaultValue(86400)
-                    ->cannotBeEmpty()
                 ->end()
                 ->scalarNode('encoder_service')
                     ->defaultValue('lexik_jwt_authentication.jwt_encoder')

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -63,9 +63,11 @@ class JWTManager implements JWTManagerInterface
      */
     public function create(UserInterface $user)
     {
-        $payload = array(
-            'exp' => time() + $this->ttl
-        );
+        $payload = array();
+
+        if(is_numeric($this->ttl)) {
+            $payload['exp'] = time() + $this->ttl;
+        }
 
         $this->addUserIdentityToPayload($user, $payload);
 


### PR DESCRIPTION
Actually `namshi/jose` does not prevent an empty ttl. Can be useful in some cases instead of setting a really long one.