### PR TITLE
Request to RequestStack (Symfony3.0 support)

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -30,7 +30,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument>%lexik_jwt_authentication.token_ttl%</argument>
             <call method="setRequest">
-                <argument type="service" id="request" on-invalid="null" strict="false" />
+                <argument type="service" id="request_stack" on-invalid="null" strict="false" />
             </call>
             <call method="setUserIdentityField">
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -8,7 +8,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTDecodedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -131,11 +131,11 @@ class JWTManager implements JWTManagerInterface
     }
 
     /**
-     * @param Request $request
+     * @param RequestStack $requestStack
      */
-    public function setRequest(Request $request = null)
+    public function setRequest(RequestStack $requestStack = null)
     {
-        $this->request = $request;
+        $this->request = $requestStack ? $requestStack->getCurrentRequest() : null;
     }
 
     /**


### PR DESCRIPTION
Hello,

With Symfony 3.0(.1), the Request service has been once for all removed from the service container. This service has been replaced by the request_stack service.

The problem was that the JWTManager is relying on the request service and as this service has been removed...

I don't know how to keep BC with SF < 2.4 (as the RequestStack has been added in SF 2.4).

Regards, 
