### PR TITLE
Use requestStack instead of request

### DIFF
--- a/DependencyInjection/Compiler/RequestCompilerPass.php
+++ b/DependencyInjection/Compiler/RequestCompilerPass.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class RequestCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('lexik_jwt_authentication.jwt_manager')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('lexik_jwt_authentication.jwt_manager');
+
+        if ($container->hasDefinition('request_stack')) {
+            $definition->addMethodCall('setRequest', array(new Reference('request_stack')));
+        } else {
+            $definition->addMethodCall('setRequest', array(new Reference('request')));
+        }
+    }
+}

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -46,19 +46,5 @@ class LexikJWTAuthenticationExtension extends Extension
             ->getDefinition('lexik_jwt_authentication.security.authentication.listener')
             ->replaceArgument(0, $tokenStorageReference)
         ;
-
-        // Call setRequest on jwt_manager with correct request service
-        if(class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            $requestStackReference = new Reference('request_stack');
-        } else {
-            $requestStackReference = new Reference('request');
-        }
-
-        $container
-            ->getDefinition('lexik_jwt_authentication.jwt_manager')
-            ->removeMethodCall('setRequest')
-            ->addMethodCall('setRequest', array($requestStackReference))
-        ;
-
     }
 }

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -46,5 +46,19 @@ class LexikJWTAuthenticationExtension extends Extension
             ->getDefinition('lexik_jwt_authentication.security.authentication.listener')
             ->replaceArgument(0, $tokenStorageReference)
         ;
+
+        // Call setRequest on jwt_manager with correct request service
+        if(class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            $requestStackReference = new Reference('request_stack');
+        } else {
+            $requestStackReference = new Reference('request');
+        }
+
+        $container
+            ->getDefinition('lexik_jwt_authentication.jwt_manager')
+            ->removeMethodCall('setRequest')
+            ->addMethodCall('setRequest', array($requestStackReference))
+        ;
+
     }
 }

--- a/LexikJWTAuthenticationBundle.php
+++ b/LexikJWTAuthenticationBundle.php
@@ -6,6 +6,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory\JW
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Compiler\RequestCompilerPass;
 
 /**
  * LexikJWTAuthenticationBundle
@@ -24,5 +25,7 @@ class LexikJWTAuthenticationBundle extends Bundle
         /** @var SecurityExtension $extension */
         $extension = $container->getExtension('security');
         $extension->addSecurityListenerFactory(new JWTFactory());
+
+        $container->addCompilerPass(new RequestCompilerPass());
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -30,7 +30,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument>%lexik_jwt_authentication.token_ttl%</argument>
             <call method="setRequest">
-                <argument type="service" id="request" on-invalid="null" strict="false" />
+                <argument type="service" id="request_stack" on-invalid="null" strict="false" />
             </call>
             <call method="setUserIdentityField">
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -30,7 +30,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument>%lexik_jwt_authentication.token_ttl%</argument>
             <call method="setRequest">
-                <argument type="service" id="request_stack" on-invalid="null" strict="false" />
+                <argument /> <!-- request_stack or request for Symfony <2.4 -->
             </call>
             <call method="setUserIdentityField">
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -29,9 +29,6 @@
             <argument type="service" id="lexik_jwt_authentication.encoder"/>
             <argument type="service" id="event_dispatcher"/>
             <argument>%lexik_jwt_authentication.token_ttl%</argument>
-            <call method="setRequest">
-                <argument /> <!-- request_stack or request for Symfony <2.4 -->
-            </call>
             <call method="setUserIdentityField">
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>
             </call>

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -134,14 +134,14 @@ class JWTManager implements JWTManagerInterface
     /**
      * @param RequestStack|Request $requestStack
      */
-    public function setRequest($requestStack = null)
+    public function setRequest($requestStack)
     {
-        if (!$requestStack instanceof Request && !$requestStack instanceof RequestStack) {
-            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\HttpFoundation\RequestStack or Symfony\Component\HttpFoundation\Request');
+        if ($requestStack instanceof Request) {
+            $this->request = $requestStack;
+        } elseif ($requestStack instanceof RequestStack) {
+            $this->request = $requestStack->getCurrentRequest();
         } else {
-            if($requestStack instanceof RequestStack) {
-                $this->request = $requestStack instanceof RequestStack ? $requestStack->getCurrentRequest() : $requestStack;
-            }
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\HttpFoundation\RequestStack or Symfony\Component\HttpFoundation\Request');
         }
     }
 

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -8,7 +8,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTDecodedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -131,11 +131,11 @@ class JWTManager implements JWTManagerInterface
     }
 
     /**
-     * @param Request $request
+     * @param RequestStack $requestStack
      */
-    public function setRequest(Request $request = null)
+    public function setRequest(RequestStack $requestStack = null)
     {
-        $this->request = $request;
+        $this->request = $requestStack ? $requestStack->getCurrentRequest() : null;
     }
 
     /**

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -8,6 +8,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTDecodedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -131,11 +132,17 @@ class JWTManager implements JWTManagerInterface
     }
 
     /**
-     * @param RequestStack $requestStack
+     * @param RequestStack|Request $requestStack
      */
-    public function setRequest(RequestStack $requestStack = null)
+    public function setRequest($requestStack = null)
     {
-        $this->request = $requestStack ? $requestStack->getCurrentRequest() : null;
+        if (!$requestStack instanceof Request && !$requestStack instanceof RequestStack) {
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\HttpFoundation\RequestStack or Symfony\Component\HttpFoundation\Request');
+        } else {
+            if($requestStack instanceof RequestStack) {
+                $this->request = $requestStack instanceof RequestStack ? $requestStack->getCurrentRequest() : $requestStack;
+            }
+        }
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,8 @@
     "require": {
         "php": ">=5.4.8",
         "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/security-bundle": "~2.3|~3.0",
+        "symfony/console": "~2.3|~3.0",
         "namshi/jose": "~6.0"
     },
     "suggest": {
@@ -41,7 +43,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.1",
+        "phpunit/phpunit": "^4.1|^5.0",
         "symfony/phpunit-bridge": "~2.7|~3.0"
     }
 }


### PR DESCRIPTION
Hello,

With Symfony 3.0(.1), the Request service has been once for all removed from the service container. This service has been replaced by the request_stack service.

The problem was that the JWTManager is relying on the request service and as this service has been removed...

I don't think it's possible to keep a backward-comptability with SF < 2.4 (ie: SF 2.3, which is a LTS ending in May 2016 ...), so maybe creating a tag could be a workaround?

I remain at your disposal for any further modifications

Regards,

PS : Sorry for the double PR, I made mistakes trying to correct a comment type ...