### PR TITLE
Always call for master request from request stack

### DIFF
--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -139,7 +139,7 @@ class JWTManager implements JWTManagerInterface
         if ($requestStack instanceof Request) {
             $this->request = $requestStack;
         } elseif ($requestStack instanceof RequestStack) {
-            $this->request = $requestStack->getCurrentRequest();
+            $this->request = $requestStack->getMasterRequest();
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixes     | #128
| License       | MIT

We had a lot of fatal errors that request is `null` after update to latest version of this bundle, this fixes all (at least from what we notice) of them.