### PR TITLE
Simplify RequestCompilerPass

### DIFF
--- a/DependencyInjection/Compiler/RequestCompilerPass.php
+++ b/DependencyInjection/Compiler/RequestCompilerPass.php
@@ -21,18 +21,12 @@ final class RequestCompilerPass implements CompilerPassInterface
             return;
         }
 
-        $definition = $container->getDefinition('lexik_jwt_authentication.jwt_manager');
+        $serviceName = $container->hasDefinition('request_stack') ? 'request_stack' : 'request';
 
-        if ($container->hasDefinition('request_stack')) {
-            $definition->addMethodCall(
-                'setRequest',
-                [new Reference('request_stack', ContainerInterface::NULL_ON_INVALID_REFERENCE, false)]
-            );
-        } else {
-            $definition->addMethodCall(
-                'setRequest',
-                [new Reference('request', ContainerInterface::NULL_ON_INVALID_REFERENCE, false)]
-            );
-        }
+        $definition = $container->getDefinition('lexik_jwt_authentication.jwt_manager');
+        $definition->addMethodCall(
+            'setRequest',
+            [new Reference($serviceName, ContainerInterface::NULL_ON_INVALID_REFERENCE)]
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes*
| New feature?  | no
| BC breaks?    | no
| License       | MIT

Removed usage of deprecated `strict` variable on reference class (it's deprecated in Symfony 2.8+)