### PR TITLE
Update Namshi/jose to 6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/security-bundle": "~2.3|~3.0",
         "symfony/console": "~2.3|~3.0",
-        "namshi/jose": "~6.0"
+        "namshi/jose": "~6.1"
     },
     "suggest": {
         "gesdinet/jwt-refresh-token-bundle": "Implements a refresh token system over Json Web Tokens in Symfony"


### PR DESCRIPTION
Hi,
Test seems to pass with this update,
Namshi/Jose 6.1 is using phpseclib 2.0.
Which is nice for using https://github.com/google/google-api-php-client combined with you bundle.

