### PR TITLE
Add response message in case of invalid token

### DIFF
--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Security\Firewall;
 use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Http\Firewall\ListenerInterface;
  * JWTListener
  *
  * @author Nicolas Cabot <n.cabot@lexik.fr>
+ * @author Robin Chalas <robin.chalas@gmail.com>
  */
 class JWTListener implements ListenerInterface
 {
@@ -78,13 +79,21 @@ class JWTListener implements ListenerInterface
             return;
 
         } catch (AuthenticationException $failed) {
+
+            $statusCode = 401;
+
             if ($this->config['throw_exceptions']) {
                 throw $failed;
             }
 
-            $response = new Response();
-            $response->setStatusCode(401);
+            $data = [
+                'code'    => $statusCode,
+                'message' => $failed->getMessage(),
+            ];
+
+            $response = new JsonResponse($data, $statusCode);
             $response->headers->set('WWW-Authenticate', 'Bearer');
+
             $event->setResponse($response);
         }
     }


### PR DESCRIPTION
In response of issue #124 , in the JWTListener I replaced the Response by a JsonResponse (such as done by the [AuthenticationFailureHandler](https://github.com/lexik/LexikJWTAuthenticationBundle/blob/master/Security/Http/Authentication/AuthenticationFailureHandler.php#L39))  but using the exception's message.

The result is that when the token is found but invalid, the following response is returned :

```json
{
  "code": 401,
  "message": "Invalid JWT Token"
}
```

Instead of an empty response as it's done currently.

If this makes sense, I can adapt the JWTListenerTest to check the behavior in this specific case (invalid token).
