### PR TITLE
Add OpenSSLKeyLoader

### DIFF
--- a/Command/CheckOpenSSLCommand.php
+++ b/Command/CheckOpenSSLCommand.php
@@ -28,51 +28,17 @@ class CheckOpenSSLCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $keyLoader = $this->getContainer()->get('lexik_jwt_authentication.openssl_key_loader');
+
         try {
-            $this->checkOpenSSLConfig(
-                $this->getContainer()->getParameter('lexik_jwt_authentication.private_key_path'),
-                $this->getContainer()->getParameter('lexik_jwt_authentication.public_key_path'),
-                $this->getContainer()->getParameter('lexik_jwt_authentication.pass_phrase')
-            );
+            $keyLoader->checkOpenSSLConfig();
         } catch (\RuntimeException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             return 1;
         }
 
         $output->writeln('<info>OpenSSL configuration seems correct.</info>');
+
         return 0;
-    }
-
-    /**
-     * Checks that configured keys exists and private key can be parsed using the passphrase
-     *
-     * @param string $privateKey
-     * @param string $publicKey
-     * @param string $passphrase
-     *
-     * @throws \RuntimeException
-     */
-    public function checkOpenSSLConfig($privateKey, $publicKey, $passphrase)
-    {
-        if (!file_exists($privateKey) || !is_readable($privateKey)) {
-            throw new \RuntimeException(sprintf(
-                'Private key "%s" does not exist or is not readable.',
-                $privateKey
-            ));
-        }
-
-        if (!file_exists($publicKey) || !is_readable($publicKey)) {
-            throw new \RuntimeException(sprintf(
-                'Public key "%s" does not exist or is not readable.',
-                $publicKey
-            ));
-        }
-
-        if (!openssl_pkey_get_private('file://' . $privateKey, $passphrase)) {
-            throw new \RuntimeException(sprintf(
-                'Failed to open private key "%s". Did you correctly configure the corresponding passphrase?',
-                $privateKey
-            ));
-        }
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,6 +9,7 @@
         <parameter key="lexik_jwt_authentication.jwt_manager.class">Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager</parameter>
         <parameter key="lexik_jwt_authentication.handler.authentication_success.class">Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler</parameter>
         <parameter key="lexik_jwt_authentication.handler.authentication_failure.class">Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationFailureHandler</parameter>
+        <parameter key="lexik_jwt_authentication.openssl_key_loader.class">Lexik\Bundle\JWTAuthenticationBundle\Services\OpenSSLKeyLoader</parameter>
         <parameter key="lexik_jwt_authentication.security.authentication.provider.class">Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Provider\JWTProvider</parameter>
         <parameter key="lexik_jwt_authentication.security.authentication.listener.class">Lexik\Bundle\JWTAuthenticationBundle\Security\Firewall\JWTListener</parameter>
         <parameter key="lexik_jwt_authentication.security.authentication.entry_point.class">Lexik\Bundle\JWTAuthenticationBundle\Security\Http\EntryPoint\JWTEntryPoint</parameter>
@@ -20,9 +21,7 @@
     <services>
         <!-- JWT Encoder / Decoder / Default implementation -->
         <service id="lexik_jwt_authentication.jwt_encoder" class="%lexik_jwt_authentication.jwt_encoder.class%">
-            <argument>%lexik_jwt_authentication.private_key_path%</argument>
-            <argument>%lexik_jwt_authentication.public_key_path%</argument>
-            <argument>%lexik_jwt_authentication.pass_phrase%</argument>
+            <argument type="service" id="lexik_jwt_authentication.openssl_key_loader"/>
         </service>
         <!-- JWT Manager / Default implementation -->
         <service id="lexik_jwt_authentication.jwt_manager" class="%lexik_jwt_authentication.jwt_manager.class%">
@@ -42,6 +41,12 @@
         <service id="lexik_jwt_authentication.handler.authentication_failure" class="%lexik_jwt_authentication.handler.authentication_failure.class%">
             <tag name="monolog.logger" channel="security"></tag>
             <argument type="service" id="event_dispatcher"/>
+        </service>
+        <!-- OpenSSL Key Loader -->
+        <service id="lexik_jwt_authentication.openssl_key_loader" class="%lexik_jwt_authentication.openssl_key_loader.class%">
+          <argument>%lexik_jwt_authentication.private_key_path%</argument>
+          <argument>%lexik_jwt_authentication.public_key_path%</argument>
+          <argument>%lexik_jwt_authentication.pass_phrase%</argument>
         </service>
         <!-- JWT Security Authentication Provider -->
         <service id="lexik_jwt_authentication.security.authentication.provider" class="%lexik_jwt_authentication.security.authentication.provider.class%" public="false">

--- a/Services/OpenSSLKeyLoader.php
+++ b/Services/OpenSSLKeyLoader.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Services;
+
+/**
+ * Load OpenSSL config keys.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class OpenSSLKeyLoader
+{
+    /**
+     * @var string
+     */
+    protected $privateKey;
+
+    /**
+     * @var string
+     */
+    protected $publicKey;
+
+    /**
+     * @var string
+     */
+    protected $passphrase;
+
+    /**
+     * Constructor.
+     *
+     * @param string $privateKey
+     * @param string $publicKey
+     * @param string $passphrase
+     */
+    public function __construct($privateKey, $publicKey, $passphrase)
+    {
+        $this->privateKey = $privateKey;
+        $this->publicKey  = $publicKey;
+        $this->passphrase = $passphrase;
+    }
+
+    /**
+     * Checks that configured keys exists and private key can be parsed using the passphrase
+     */
+    public function checkOpenSSLConfig()
+    {
+        $this->loadKey('public');
+        $this->loadKey('private');
+    }
+
+    /**
+     * Load a key from a given type (public or private).
+     *
+     * @param string Either
+     *
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function loadKey($type)
+    {
+        $property = $type . 'Key';
+        $path = $this->$property;
+
+        if (!file_exists($path) || !is_readable($path)) {
+            throw new \RuntimeException(sprintf(
+                '%s key "%s" does not exist or is not readable. Did you correctly set the "lexik_jwt_authentication.%s_key_path" parameter?',
+                ucfirst($type),
+                $path,
+                $type
+            ));
+        }
+
+        $loadPath = 'file://' . $path;
+        $key = call_user_func_array(
+            sprintf('openssl_pkey_get_%s', $type),
+            $type == 'private' ? [$loadPath, $this->passphrase] : [$loadPath]
+        );
+
+        if (!$key) {
+            throw new \RuntimeException(sprintf(
+                'Failed to load %s key "%s". Did you correctly configure the corresponding passphrase?',
+                $type,
+                $path
+            ));
+        }
+
+        return $key;
+    }
+}

--- a/Tests/Services/OpenSSLKeyLoaderTest.php
+++ b/Tests/Services/OpenSSLKeyLoaderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Services;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Services\OpenSSLKeyLoader;
+
+/**
+ * OpenSSLKeyLoaderTest
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class OpenSSLKeyLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var OpenSSLKeyLoader */
+    protected $keyLoader;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->keyLoader = new OpenSSLKeyLoader('private.pem', 'public.pem', 'foobar');
+    }
+
+    /**
+     * Test load unreadable public key.
+     *
+     * @expectedException        RuntimeException
+     * @expectedExceptionMessage Public key "public.pem" does not exist or is not readable.
+     */
+    public function testLoadUnreadablePublicKey()
+    {
+        $this->keyLoader->loadKey('public');
+    }
+
+    /**
+     * Test load unreadable private key.
+     *
+     * @expectedException        RuntimeException
+     * @expectedExceptionMessage Private key "private.pem" does not exist or is not readable.
+     */
+    public function testLoadUnreadablePrivateKey()
+    {
+        $this->keyLoader->loadKey('private');
+    }
+
+    /**
+     * Test load unreadable private key.
+     *
+     * @expectedException        RuntimeException
+     * @expectedExceptionMessage Failed to load public key "public.pem".
+     */
+    public function testLoadInvalidPublicKey()
+    {
+        touch('public.pem');
+
+        $this->keyLoader->loadKey('public');
+    }
+
+    /**
+     * Test load unreadable private key.
+     *
+     * @expectedException        RuntimeException
+     * @expectedExceptionMessage Failed to load private key "private.pem".
+     */
+    public function testLoadInvalidPrivateKey()
+    {
+        touch('private.pem');
+
+        $this->keyLoader->loadKey('private');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown()
+    {
+        $privateKey = 'private.pem';
+        $publicKey  = 'public.pem';
+
+        if (file_exists($publicKey)) {
+            unlink($publicKey);
+        }
+
+        if (file_exists($privateKey)) {
+            unlink($privateKey);
+        }
+    }
+}


### PR DESCRIPTION
Add a service that loads keys from parameters (key paths and passphrase as arguments of the service).
The service has been injected in the JWTEncoder rather than the 3 parameters, same for the method `checkOpenSSLConfig` that has been moved in the service and now takes no argument.

This also Improve checks for keys and their corresponding exception messages (One for file existing/reading problem, one for openssl loading, this for both public and private keys).

This avoid duplicated code (Command & Encoder) and make the bundle configuration easier to debug (centralised key loading logic).