### PR TITLE
Allow to set a custom response in case of authentication failure or invalid/not found token

### DIFF
--- a/Event/AuthenticationFailureEvent.php
+++ b/Event/AuthenticationFailureEvent.php
@@ -11,6 +11,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  * AuthenticationFailureEvent
  *
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
+ * @author Robin Chalas   <robin.chalas@gmail.com>
  */
 class AuthenticationFailureEvent extends Event
 {
@@ -36,9 +37,9 @@ class AuthenticationFailureEvent extends Event
      */
     public function __construct(Request $request, AuthenticationException $exception, Response $response)
     {
-        $this->request = $request;
+        $this->request   = $request;
         $this->exception = $exception;
-        $this->response = $response;
+        $this->response  = $response;
     }
 
     /**
@@ -63,5 +64,13 @@ class AuthenticationFailureEvent extends Event
     public function getResponse()
     {
         return $this->response;
+    }
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
     }
 }

--- a/Event/JWTInvalidEvent.php
+++ b/Event/JWTInvalidEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
+
+/**
+ * JWTInvalidEvent
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class JWTInvalidEvent extends AuthenticationFailureEvent
+{
+}

--- a/Events.php
+++ b/Events.php
@@ -16,7 +16,8 @@ final class Events
     const AUTHENTICATION_SUCCESS = 'lexik_jwt_authentication.on_authentication_success';
 
     /**
-     * Dispatched after an authentication failure
+     * Dispatched after an authentication failure.
+     * Hook into this event to add a custom error message in the response body.
      */
     const AUTHENTICATION_FAILURE = 'lexik_jwt_authentication.on_authentication_failure';
 
@@ -43,4 +44,10 @@ final class Events
      * Hook into this event to perform additional modification to the authenticated token using the payload.
      */
     const JWT_AUTHENTICATED = 'lexik_jwt_authentication.on_jwt_authenticated';
+
+    /**
+     * Dispatched after the token has been invalidated by the provider.
+     * Hook into this event to add a custom error message in the response body.
+     */
+    const JWT_INVALID = 'lexik_jwt_authentication.on_jwt_invalid';
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -62,6 +62,9 @@
             <argument /> <!-- security.token_storage or security.context for Symfony <2.6 -->
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Options -->
+            <call method="setDispatcher">
+                <argument type="service" id="event_dispatcher"/>
+            </call>
         </service>
         <!-- Authorization Header Token Extractor -->
         <service id="lexik_jwt_authentication.extractor.authorization_header_extractor" class="%lexik_jwt_authentication.extractor.authorization_header_extractor.class%" public="false">

--- a/Tests/Security/Authentication/Firewall/JWTListenerTest.php
+++ b/Tests/Security/Authentication/Firewall/JWTListenerTest.php
@@ -20,11 +20,13 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
         // no token extractor : should return void
 
         $listener = new JWTListener($this->getTokenStorageMock(), $this->getAuthenticationManagerMock());
+        $listener->setDispatcher($this->getEventDispatcherMock());
         $this->assertNull($listener->handle($this->getEvent()));
 
         // one token extractor with no result : should return void
 
         $listener = new JWTListener($this->getTokenStorageMock(), $this->getAuthenticationManagerMock());
+        $listener->setDispatcher($this->getEventDispatcherMock());
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock(false));
         $this->assertNull($listener->handle($this->getEvent()));
 
@@ -34,6 +36,7 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
         $authenticationManager->expects($this->once())->method('authenticate');
 
         $listener = new JWTListener($this->getTokenStorageMock(), $authenticationManager);
+        $listener->setDispatcher($this->getEventDispatcherMock());
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock('token'));
         $listener->handle($this->getEvent());
 
@@ -50,6 +53,7 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->throwException($invalidTokenException));
 
         $listener = new JWTListener($this->getTokenStorageMock(), $authenticationManager);
+        $listener->setDispatcher($this->getEventDispatcherMock());
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock('token'));
 
         $event = $this->getEvent();
@@ -133,5 +137,15 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($request));
 
         return $event;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getEventDispatcherMock()
+    {
+        return $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 }


### PR DESCRIPTION
| Q             | A    |
|---------------|------|
| Bug fix?      | yes  |
| New feature?  | yes  |
| BC breaks?    | no   |
| Fixed tickets | #153 |
| Tests pass?   | yes  |

This make developers able to subscribe on the  `AUTHENTICATION_FAILURE` / `INVALID_JWT` events.

The first is dispatched when the provider cannot retrieve/authenticate credentials sent to the login route.
The second (new) is dispatched when the listener cannot retrieve/authenticate a token on a secured route.

Tests and documentation have been updated.