### PR TITLE
Fix anonymous access by removing the AuthenticationCredentialsNotFoundException 

### DIFF
--- a/Resources/doc/2-data-customization.md
+++ b/Resources/doc/2-data-customization.md
@@ -232,7 +232,7 @@ public function onAuthenticationFailureResponse(AuthenticationFailureEvent $even
 
 #### Events::JWT_INVALID - customize the invalid token response
 
-By default, if the token is invalid or not set, the response is just a json containing the corresponding error message and a 401 status code, but you can set a custom response.
+By default, if the token is invalid, the response is just a json containing the corresponding error message and a 401 status code, but you can set a custom response.
 
 ``` yaml
 # services.yml

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -12,7 +12,6 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -74,9 +73,11 @@ class JWTListener implements ListenerInterface
     {
         $request = $event->getRequest();
 
-        try {
+        if (!$requestToken = $this->getRequestToken($request)) {
+            return;
+        }
 
-            $requestToken = $this->getRequestToken($request);
+        try {
 
             $token = new JWTUserToken();
             $token->setRawToken($requestToken);
@@ -137,6 +138,6 @@ class JWTListener implements ListenerInterface
             }
         }
 
-        throw new AuthenticationCredentialsNotFoundException('No JWT token found');
+        return false;
     }
 }


### PR DESCRIPTION
| Q             | A    |
|---------------|------|
| Bug fix?      | yes  |
| New feature?  | no |
| BC breaks?    | no   |
| Fixed tickets | no |
| Tests pass?   | yes  |

For now, we can't handle the case of no token found in request, so I revert a part of my previous #157.
The problem is that we can't know if the current request can be done anonymously.

@slashfan If you see any way to know if the current request can be authenticated anonymously or not (retrieve firewall config?), I could be able to add a check and throw the exception only if the request cannot be authenticated anonymously.