### PR TITLE
Remove Symfony versions < 2.8 from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,6 @@ php:
 matrix:
   fast_finish: true
   include:
-    - php: 5.4
-      env: SYMFONY_VERSION=2.3.*
-    - php: 5.5
-      env: SYMFONY_VERSION=2.3.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.3.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.7.*
-    - php: 7.0
-      env: SYMFONY_VERSION=2.7.*
     - php: 5.6
       env: SYMFONY_VERSION=2.8.*
     - php: 7.0


### PR DESCRIPTION
After discussed in #132, we stop supporting Symfony versions lower than 2.8 and so stop ensuring compatibility with these versions on travis-ci.

Open to any suggestion (missing version, specific php version for specific symfony one, ...).