### PR TITLE
PSR-4 Autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,8 @@
         "gesdinet/jwt-refresh-token-bundle": "Implements a refresh token system over Json Web Tokens in Symfony"
     },
     "autoload": {
-        "psr-0": { "Lexik\\Bundle\\JWTAuthenticationBundle": "" }
+        "psr-4": { "Lexik\\Bundle\\JWTAuthenticationBundle\\": "" }
     },
-    "target-dir": "Lexik/Bundle/JWTAuthenticationBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "2.0.x-dev"


### PR DESCRIPTION
> The PSR-4 autoload standard is recommended for modern bundles

From [Symfony best practices for reusable bundles](http://symfony.com/doc/current/cookbook/bundles/best_practices.html#composer-metadata).
