### PR TITLE
Composer aliases for dev-master & 2.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "target-dir": "Lexik/Bundle/JWTAuthenticationBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "1.x-dev"
         }
     },
     "require-dev": {


### PR DESCRIPTION
Like this, anyone can use the `master` branch by requiring `1.x-dev`, and use the `2.0` branch by requiring `2.0.x-dev` (alias automatically added by packagist).

(should be merged in `2.0` too).