### PR TITLE
Remove PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0


### PR DESCRIPTION
As discussed in #167, we stop testing on PHP versions < 5.5.