### PR TITLE
Add JWTAuthenticationResponse

### DIFF
--- a/Resources/doc/2-data-customization.md
+++ b/Resources/doc/2-data-customization.md
@@ -169,8 +169,6 @@ public function onAuthenticationSuccessResponse(AuthenticationSuccessEvent $even
         return;
     }
 
-    // $data['token'] contains the JWT
-
     $data['data'] = array(
         'roles' => $user->getRoles(),
     );
@@ -199,7 +197,7 @@ public function onJwtEncoded(JWTEncodedEvent $event)
 
 #### Events::AUTHENTICATION_FAILURE - customize the failure response
 
-By default, the response in case of failed authentication is just a json containing a "Bad credentials" message and a 401 status code, but you can set a custom response.
+By default, the response in case of failed authentication is just a json containing a failure message and a 401 status code, but you can set a custom response.
 
 ``` yaml
 # services.yml
@@ -214,6 +212,9 @@ Example 7: set a custom response on authentication failure
 
 ``` php
 // Acme\Bundle\ApiBundle\EventListener\AuthenticationFailureListener.php
+
+use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
+
 /**
  * @param AuthenticationFailureEvent $event
  */
@@ -224,7 +225,7 @@ public function onAuthenticationFailureResponse(AuthenticationFailureEvent $even
         'message' => 'Bad credentials, please verify that your username/password are correctly set',
     ];
 
-    $response = new JsonResponse($data, 401);
+    $response = new JWTAuthenticationFailureResponse($data);
 
     $event->setResponse($response);
 }
@@ -243,21 +244,19 @@ services:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_invalid, method: onJWTInvalid }
 ```
 
-Example 8: set a custom response message on invalid token
+Example 8: set a custom response message and status code on invalid token
 
 ``` php
 // Acme\Bundle\ApiBundle\EventListener\JWTInvalidListener.php
+
+use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
+
 /**
  * @param JWTInvalidEvent $event
  */
 public function onJWTInvalid(JWTInvalidEvent $event)
 {
-    $data = [
-        'status'  => '403 Forbidden',
-        'message' => 'Your token is invalid, please login again to get a new one',
-    ];
-
-    $response = new JsonResponse($data, 403);
+    $response = new JWTAuthenticationFailureResponse('Your token is invalid, please login again to get a new one', 403);
 
     $event->setResponse($response);
 }

--- a/Response/JWTAuthenticationFailureResponse.php
+++ b/Response/JWTAuthenticationFailureResponse.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Response;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * JWTAuthenticationFailureResponse.
+ *
+ * Response sent on failed JWT authentication (can be replaced by a custom Response).
+ *
+ * @internal
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class JWTAuthenticationFailureResponse extends JsonResponse
+{
+    /**
+     * The response message.
+     *
+     * @var string
+     */
+    private $message;
+
+    /**
+     * @param string $message A failure message passed in the response body
+     */
+    public function __construct($message = 'Bad credentials')
+    {
+        $this->message = $message;
+
+        parent::__construct(null, self::HTTP_UNAUTHORIZED, ['WWW-Authenticate' => 'Bearer']);
+
+        $this->setData([
+            'code'    => $this->statusCode,
+            'message' => $this->message,
+        ]);
+    }
+
+    /**
+     * Sets the failure message.
+     *
+     * @param string $message
+     *
+     * @return JWTAuthenticationFailureResponse
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+
+        return $this;
+    }
+
+    /**
+     * Gets the failure message.
+     *
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/Response/JWTAuthenticationFailureResponse.php
+++ b/Response/JWTAuthenticationFailureResponse.php
@@ -25,16 +25,11 @@ final class JWTAuthenticationFailureResponse extends JsonResponse
     /**
      * @param string $message A failure message passed in the response body
      */
-    public function __construct($message = 'Bad credentials')
+    public function __construct($message = 'Bad credentials', $statusCode = JsonResponse::HTTP_UNAUTHORIZED)
     {
         $this->message = $message;
 
-        parent::__construct(null, self::HTTP_UNAUTHORIZED, ['WWW-Authenticate' => 'Bearer']);
-
-        $this->setData([
-            'code'    => $this->statusCode,
-            'message' => $this->message,
-        ]);
+        parent::__construct(null, $statusCode, ['WWW-Authenticate' => 'Bearer']);
     }
 
     /**
@@ -48,6 +43,8 @@ final class JWTAuthenticationFailureResponse extends JsonResponse
     {
         $this->message = $message;
 
+        $this->setData();
+
         return $this;
     }
 
@@ -59,5 +56,15 @@ final class JWTAuthenticationFailureResponse extends JsonResponse
     public function getMessage()
     {
         return $this->message;
+    }
+
+    /**
+     * Sets the response data with the statusCode & message included.
+     *
+     * {@inheritdoc}
+     */
+    public function setData($data = [])
+    {
+        parent::setData(['code' => $this->statusCode, 'message' => $this->message] + (array) $data);
     }
 }

--- a/Response/JWTAuthenticationSuccessResponse.php
+++ b/Response/JWTAuthenticationSuccessResponse.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Response;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Response sent on successful JWT authentication.
+ *
+ * @internal
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class JWTAuthenticationSuccessResponse extends JsonResponse
+{
+    /**
+     * The Json Web Token.
+     *
+     * Immutable property.
+     *
+     * @var string
+     */
+    private $token;
+
+    /**
+     * @param string $token   Json Web Token
+     * @param array  $data    Extra data passed to the response body.
+     * @param array  $headers HTTP headers
+     */
+    public function __construct($token, array $extraData = [])
+    {
+        $this->token     = $token;
+        $this->extraData = $extraData;
+
+        parent::__construct();
+
+        $this->setBody();
+    }
+
+    /**
+     * Gets the Json Web Token.
+     *
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setExtraData(array $extraData = [])
+    {
+        $this->extraData = $extraData;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtraData()
+    {
+        return $this->extraData;
+    }
+
+    /**
+     * Prevents unexpected response content.
+     *
+     * @internal
+     *
+     * {@inheritdoc}
+     */
+    public function setData($data = [])
+    {
+        return $this->setBody();
+    }
+
+    /**
+     * Creates the response body.
+     *
+     * @return JWTAuthenticationSuccessResponse
+     */
+    private function setBody()
+    {
+        parent::setData(['token' => $this->token] + $this->extraData);
+    }
+}

--- a/Response/JWTAuthenticationSuccessResponse.php
+++ b/Response/JWTAuthenticationSuccessResponse.php
@@ -23,67 +23,23 @@ final class JWTAuthenticationSuccessResponse extends JsonResponse
     private $token;
 
     /**
-     * @param string $token   Json Web Token
-     * @param array  $data    Extra data passed to the response body.
-     * @param array  $headers HTTP headers
+     * @param string $token Json Web Token
+     * @param array  $data  Extra data passed to the response.
      */
-    public function __construct($token, array $extraData = [])
+    public function __construct($token, array $data = null)
     {
-        $this->token     = $token;
-        $this->extraData = $extraData;
+        $this->token = $token;
 
-        parent::__construct();
-
-        $this->setBody();
+        parent::__construct($data);
     }
 
     /**
-     * Gets the Json Web Token.
-     *
-     * @return string
-     */
-    public function getToken()
-    {
-        return $this->token;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setExtraData(array $extraData = [])
-    {
-        $this->extraData = $extraData;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getExtraData()
-    {
-        return $this->extraData;
-    }
-
-    /**
-     * Prevents unexpected response content.
-     *
-     * @internal
+     * Sets the response data with the JWT included.
      *
      * {@inheritdoc}
      */
     public function setData($data = [])
     {
-        return $this->setBody();
-    }
-
-    /**
-     * Creates the response body.
-     *
-     * @return JWTAuthenticationSuccessResponse
-     */
-    private function setBody()
-    {
-        parent::setData(['token' => $this->token] + $this->extraData);
+        parent::setData(['token' => $this->token] + (array) $data);
     }
 }

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -6,8 +6,8 @@ use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -91,13 +91,7 @@ class JWTListener implements ListenerInterface
                 throw $failed;
             }
 
-            $data = [
-                'code'    => 401,
-                'message' => $failed->getMessage(),
-            ];
-
-            $response = new JsonResponse($data, $data['code']);
-            $response->headers->set('WWW-Authenticate', 'Bearer');
+            $response = new JWTAuthenticationFailureResponse($failed->getMessage());
 
             $jwtInvalidEvent = new JWTInvalidEvent($request, $failed, $response);
             $this->dispatcher->dispatch(Events::JWT_INVALID, $jwtInvalidEvent);

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -4,8 +4,8 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationFailureEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
@@ -17,9 +17,6 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerI
  */
 class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterface
 {
-    const RESPONSE_CODE    = 401;
-    const RESPONSE_MESSAGE = 'Bad credentials';
-
     /**
      * @var EventDispatcherInterface
      */
@@ -38,13 +35,7 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        $data = [
-            'code'    => self::RESPONSE_CODE,
-            'message' => self::RESPONSE_MESSAGE,
-        ];
-
-        $response = new JsonResponse($data, self::RESPONSE_CODE);
-        $event = new AuthenticationFailureEvent($request, $exception, $response);
+        $event = new AuthenticationFailureEvent($request, $exception, new JWTAuthenticationFailureResponse());
 
         $this->dispatcher->dispatch(Events::AUTHENTICATION_FAILURE, $event);
 

--- a/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -5,8 +5,8 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
+use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationSuccessResponse;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
@@ -43,14 +43,13 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
      */
     public function onAuthenticationSuccess(Request $request, TokenInterface $token)
     {
-        $user = $token->getUser();
-        $jwt  = $this->jwtManager->create($user);
-
-        $response = new JsonResponse();
+        $user     = $token->getUser();
+        $jwt      = $this->jwtManager->create($user);
+        $response = new JWTAuthenticationSuccessResponse($jwt);
         $event    = new AuthenticationSuccessEvent(['token' => $jwt], $user, $request, $response);
 
         $this->dispatcher->dispatch(Events::AUTHENTICATION_SUCCESS, $event);
-        $response->setData($event->getData());
+        $response->setExtraData($event->getData());
 
         return $response;
     }

--- a/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -49,7 +49,7 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
         $event    = new AuthenticationSuccessEvent(['token' => $jwt], $user, $request, $response);
 
         $this->dispatcher->dispatch(Events::AUTHENTICATION_SUCCESS, $event);
-        $response->setExtraData($event->getData());
+        $response->setData($event->getData());
 
         return $response;
     }

--- a/Security/Http/EntryPoint/JWTEntryPoint.php
+++ b/Security/Http/EntryPoint/JWTEntryPoint.php
@@ -2,8 +2,8 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Security\Http\EntryPoint;
 
+use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
@@ -19,15 +19,7 @@ class JWTEntryPoint implements AuthenticationEntryPointInterface
      */
     public function start(Request $request, AuthenticationException $authException = null)
     {
-        $statusCode = 401;
-
-        $data = [
-            'code'    => $statusCode,
-            'message' => 'Invalid credentials',
-        ];
-
-        $response = new JsonResponse($data, $statusCode);
-        $response->headers->set('WWW-Authenticate', 'Bearer');
+        $response = new JWTAuthenticationFailureResponse();
 
         return $response;
     }

--- a/Tests/Functional/config/config.yml
+++ b/Tests/Functional/config/config.yml
@@ -4,8 +4,8 @@ framework:
         resource: %kernel.root_dir%/config/routing.yml
 
 lexik_jwt_authentication:
-    private_key_path:   %kernel.root_dir%/var/private.pem
-    public_key_path:    %kernel.root_dir%/var/public.pem
+    private_key_path:   '%kernel.root_dir%/var/private.pem'
+    public_key_path:    '%kernel.root_dir%/var/public.pem'
     pass_phrase:        testing
 
 security:

--- a/Tests/Response/JWTAuthenticationFailureResponseTest.php
+++ b/Tests/Response/JWTAuthenticationFailureResponseTest.php
@@ -27,4 +27,19 @@ final class JWTAuthenticationFailureResponseTest extends \PHPUnit_Framework_Test
 
         return $response;
     }
+
+    /**
+     * @depends testResponse
+     */
+    public function testSetMessage(JWTAuthenticationFailureResponse $response)
+    {
+        $newMessage = 'new message';
+        $response->setMessage($newMessage);
+
+        $responseBody = json_decode($response->getContent());
+
+        $this->assertSame($response->getStatusCode(), $responseBody->code);
+        $this->assertSame($newMessage, $response->getMessage());
+        $this->assertSame($newMessage, $responseBody->message);
+    }
 }

--- a/Tests/Response/JWTAuthenticationFailureResponseTest.php
+++ b/Tests/Response/JWTAuthenticationFailureResponseTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Response;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
+
+/**
+ * Tests the JWTAuthenticationFailureResponse
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class JWTAuthenticationFailureResponseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testResponse()
+    {
+        $expected = [
+            'code'    => 401,
+            'message' => 'message',
+        ];
+
+        $response = new JWTAuthenticationFailureResponse($expected['message']);
+
+        $this->assertSame($expected['message'], $response->getMessage());
+        $this->assertSame($expected['code'], $response->getStatusCode());
+        $this->assertSame('Bearer', $response->headers->get('WWW-Authenticate'));
+        $this->assertSame(json_encode($expected), $response->getContent());
+
+        return $response;
+    }
+}

--- a/Tests/Response/JWTAuthenticationSuccessResponseTest.php
+++ b/Tests/Response/JWTAuthenticationSuccessResponseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Response;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationSuccessResponse;
+
+/**
+ * Tests the JWTAuthenticationSuccessResponse.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class JWTAuthenticationSuccessResponseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testResponse()
+    {
+        $extraData = [
+            'username' => 'foobar',
+            'email'    => 'dev@lexik.fr'
+        ];
+        $expected = ['token' => 'jwt'] + $extraData;
+
+        $response = new JWTAuthenticationSuccessResponse($expected['token'], $extraData);
+
+        $this->assertSame($expected['token'], $response->getToken());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame($extraData, $response->getExtraData());
+
+        $this->assertSame(json_encode($expected), $response->getContent());
+
+        return $response;
+    }
+
+    /**
+     * @depends testResponse
+     */
+    public function testReplaceData(JWTAuthenticationSuccessResponse $response)
+    {
+        $replacementData = ['foo' => 'bar'];
+        $response->setData($replacementData);
+
+        // Test that the previous method call has no effect on the original body
+        $this->assertNotEquals(json_encode($replacementData), $response->getContent());
+        $this->assertSame(
+            json_encode(['token' => $response->getToken()] + $response->getExtraData()),
+            $response->getContent()
+        );
+    }
+}

--- a/Tests/Response/JWTAuthenticationSuccessResponseTest.php
+++ b/Tests/Response/JWTAuthenticationSuccessResponseTest.php
@@ -13,18 +13,14 @@ final class JWTAuthenticationSuccessResponseTest extends \PHPUnit_Framework_Test
 {
     public function testResponse()
     {
-        $extraData = [
+        $data = [
             'username' => 'foobar',
             'email'    => 'dev@lexik.fr'
         ];
-        $expected = ['token' => 'jwt'] + $extraData;
+        $expected = ['token' => 'jwt'] + $data;
+        $response = new JWTAuthenticationSuccessResponse($expected['token'], $data);
 
-        $response = new JWTAuthenticationSuccessResponse($expected['token'], $extraData);
-
-        $this->assertSame($expected['token'], $response->getToken());
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame($extraData, $response->getExtraData());
-
         $this->assertSame(json_encode($expected), $response->getContent());
 
         return $response;
@@ -40,9 +36,7 @@ final class JWTAuthenticationSuccessResponseTest extends \PHPUnit_Framework_Test
 
         // Test that the previous method call has no effect on the original body
         $this->assertNotEquals(json_encode($replacementData), $response->getContent());
-        $this->assertSame(
-            json_encode(['token' => $response->getToken()] + $response->getExtraData()),
-            $response->getContent()
-        );
+        $this->assertAttributeSame($replacementData['foo'], 'foo', json_decode($response->getContent()));
+        $this->assertAttributeNotEmpty('token', json_decode($response->getContent()));
     }
 }

--- a/Tests/Security/Authentication/Firewall/JWTListenerTest.php
+++ b/Tests/Security/Authentication/Firewall/JWTListenerTest.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Security\Authentication\Firewall;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Firewall\JWTListener;
+use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
 
 /**
  * JWTListenerTest
@@ -60,10 +61,7 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
         $event
             ->expects($this->once())
             ->method('setResponse')
-            ->with(new \Symfony\Component\HttpFoundation\JsonResponse([
-                'code'    => 401,
-                'message' => $invalidTokenException->getMessage(),
-            ], 401, ['WWW-Authenticate' => 'Bearer']));
+            ->with(new JWTAuthenticationFailureResponse($invalidTokenException->getMessage()));
 
         $listener->handle($event);
     }

--- a/Tests/Security/Http/EntryPoint/JWTEntryPointTest.php
+++ b/Tests/Security/Http/EntryPoint/JWTEntryPointTest.php
@@ -24,7 +24,7 @@ class JWTEntryPointTest extends \PHPUnit_Framework_TestCase
 
         $data = json_decode($response->getContent(), true);
         $this->assertEquals($data['code'], '401');
-        $this->assertEquals($data['message'], 'Invalid credentials');
+        $this->assertEquals($data['message'], 'Bad credentials');
     }
 
     /**


### PR DESCRIPTION
| Q             | A    |
|---------------|------|
| Bug fix?      | no  |
| New feature?  | yes |
| BC breaks?    | no  |
| Deprecations | yes |
| Fixed tickets | n/a |
| Tests pass?   | yes  |

This introduces a generic Response class for successful/failed authentication.
BTW remove duplicated failure Responses with pretty much the same data (3times).

Let me know what do you think.

Steps:

- [x] Add JWTAuthenticationFailureResponse & JWTAuthenticationSuccessResponses
- [x] Add tests
- [x] Update documentation