### PR TITLE
Reference compatibility breaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
       env: SYMFONY_VERSION=3.0.*
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.1.*
+    - php: 7.0
+      env: SYMFONY_VERSION=3.1.*
   allow_failures:
     - php: hhvm
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ CHANGELOG
 
 For a diff between two versions https://github.com/lexik/LexikJWTAuthenticationBundle/compare/v1.0.0...v1.5.0
 
+## [2.0](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/2.0)
+
+* [\#175](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/175) Stop ensuring support for PHP versions smaller than 5.0 ([chalasr](https://github.com/chalasr))
+
+* [\#167](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/167) and [\#169](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/169) Stop ensuring support Symfony versions smaller than 2.8 ([chalasr](https://github.com/chalasr))
+
 ## [v1.5.1](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v1.5.1) (2016-04-11)
 
 * bug [\#159](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/159) Fix anonymous access by removing the AuthenticationCredentialsNotFoundException  ([chalasr](https://github.com/chalasr))

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ LexikJWTAuthenticationBundle
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/67573b6f-e182-4394-b26a-649c323784f6/mini.png)](https://insight.sensiolabs.com/projects/67573b6f-e182-4394-b26a-649c323784f6)
 [![Latest Stable Version](https://poser.pugx.org/lexik/jwt-authentication-bundle/v/stable.svg)](https://packagist.org/packages/lexik/jwt-authentication-bundle)
 
-This bundle provides JWT (Json Web Token) authentication for your Symfony REST API using the [`namshi/jose`](https://github.com/namshi/jose) library.
+This bundle provides JWT (Json Web Token) authentication for your Symfony REST API default using the [`namshi/jose`](https://github.com/namshi/jose) library.
 
-It is compatible and tested with PHP 5.4, 5.5, 5.6, 7.0, HHVM and Symfony 2.3, 2.7, 2.8 and 3.0.
+It is compatible and tested with PHP 5.5, 5.6, 7.0, HHVM and Symfony 2.8, 3.0 and 3.1.
 
 Documentation
 -------------


### PR DESCRIPTION
- [x] Update README support and pre-requisites.
- [x] Allow Symfony 3.1 (If tests pass)