### PR TITLE
[DX] Add JWTNotFoundEvent

### DIFF
--- a/Event/JWTFailureEventInterface.php
+++ b/Event/JWTFailureEventInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Interface for event classes that are dispatched when a JWT cannot be authenticated.
+ * 
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+interface JWTFailureEventInterface
+{
+    /**
+     * @return Response
+     */
+    public function getResponse();
+
+    /**
+     * @return Request
+     */
+    public function getRequest();
+
+    /**
+     * @return AuthenticationException
+     */
+    public function getException();
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response);
+}

--- a/Event/JWTInvalidEvent.php
+++ b/Event/JWTInvalidEvent.php
@@ -7,6 +7,6 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-class JWTInvalidEvent extends AuthenticationFailureEvent
+class JWTInvalidEvent extends AuthenticationFailureEvent implements JWTFailureEventInterface
 {
 }

--- a/Event/JWTNotFoundEvent.php
+++ b/Event/JWTNotFoundEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * JWTNotFoundEvent event is dispatched when a JWT cannot be found in a request 
+ * covered by a firewall secured via lexik_jwt.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class JWTNotFoundEvent extends AuthenticationFailureEvent implements JWTFailureEventInterface
+{
+    /**
+     * @param Request                      $request
+     * @param AuthenticationException|null $exception
+     * @param Response|null                $response
+     */
+    public function __construct(Request $request, AuthenticationException $exception = null, Response $response = null)
+    {
+        $this->request   = $request;
+        $this->exception = $exception;
+        $this->response  = $response;
+    }
+}

--- a/Events.php
+++ b/Events.php
@@ -50,4 +50,10 @@ final class Events
      * Hook into this event to add a custom error message in the response body.
      */
     const JWT_INVALID = 'lexik_jwt_authentication.on_jwt_invalid';
+
+    /**
+     * Dispatched when no token can be found in a request.
+     * Hook into this event to set a custom response.
+     */
+    const JWT_NOT_FOUND = 'lexik_jwt_authentication.on_jwt_not_found';
 }

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -5,6 +5,7 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Security\Firewall;
 use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTNotFoundEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -74,6 +75,13 @@ class JWTListener implements ListenerInterface
         $request = $event->getRequest();
 
         if (!$requestToken = $this->getRequestToken($request)) {
+            $jwtNotFoundEvent = new JWTNotFoundEvent($request);
+            $this->dispatcher->dispatch(Events::JWT_NOT_FOUND, $jwtNotFoundEvent);
+
+            if ($response = $jwtNotFoundEvent->getResponse()) {
+                $event->setResponse($response);
+            }
+            
             return;
         }
 

--- a/Tests/Security/Authentication/Firewall/JWTListenerTest.php
+++ b/Tests/Security/Authentication/Firewall/JWTListenerTest.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Security\Authentication\Firewall;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Firewall\JWTListener;
+use Lexik\Bundle\JWTAuthenticationBundle\Events;
 
 /**
  * JWTListenerTest
@@ -26,7 +27,16 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
         // one token extractor with no result : should return void
 
         $listener = new JWTListener($this->getTokenStorageMock(), $this->getAuthenticationManagerMock());
-        $listener->setDispatcher($this->getEventDispatcherMock());
+        $dispatcher = $this->getEventDispatcherMock();
+        $dispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                $this->equalTo(Events::JWT_NOT_FOUND),
+                $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTNotFoundEvent')
+            );
+        
+        $listener->setDispatcher($dispatcher);
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock(false));
         $this->assertNull($listener->handle($this->getEvent()));
 
@@ -53,7 +63,15 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->throwException($invalidTokenException));
 
         $listener = new JWTListener($this->getTokenStorageMock(), $authenticationManager);
-        $listener->setDispatcher($this->getEventDispatcherMock());
+        $dispatcher = $this->getEventDispatcherMock();
+        $dispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                $this->equalTo(Events::JWT_INVALID),
+                $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent')
+            );
+        $listener->setDispatcher($dispatcher);
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock('token'));
 
         $event = $this->getEvent();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      |  no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #187, https://github.com/lexik/LexikJWTAuthenticationBundle/pull/159#issuecomment-208228006
| Tests pass?   | yes

As discussed in the fixed tickets,, I propose to add a specific `JWT_NOT_FOUND`, making users able to catch this event and set a custom response if they want, or just ignore it.
It can be useful to secure routes that are part of anonymous firewalls, for restrict it to a specific user role for instance, or just have the same behaviour as on `JWT_INVALID`.

Also it introduces an interface implemented by both `JWT_NOT_FOUND` and `JWT_INVALID`, so the same (listener) method can be used to listen on both events.

Closes #187. 