### PR TITLE
[KeyLoader] Fix tests on HHVM using file_get_contents

### DIFF
--- a/Services/OpenSSLKeyLoader.php
+++ b/Services/OpenSSLKeyLoader.php
@@ -70,10 +70,10 @@ class OpenSSLKeyLoader
             ));
         }
 
-        $loadPath = 'file://' . $path;
+        $encryptedKey = file_get_contents($path);
         $key = call_user_func_array(
             sprintf('openssl_pkey_get_%s', $type),
-            $type == 'private' ? [$loadPath, $this->passphrase] : [$loadPath]
+            $type == 'private' ? [$encryptedKey, $this->passphrase] : [$encryptedKey]
         );
 
         if (!$key) {


### PR DESCRIPTION
Tests are broken on HHVM since the KeyLoader uses `file://`, the problem was hidden before that the OpenSSLKeyLoader exists, because this part was not precisely tested).

So I did the same as in the new key loader added in `2.0`. It now uses `file_get_contents([KEY PATH])` rather than `file://[KEY PATH]` as first argument of `open_ssl_pkey_get`. 