### PR TITLE
Fix phpunit deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.1|^5.0",
+        "phpunit/phpunit": "~4.1",
         "symfony/phpunit-bridge": "~2.7|~3.0",
         "friendsofphp/php-cs-fixer": "~1.1"
     }


### PR DESCRIPTION
When using phpunit `>= 5.4.0`, we this deprecation warning occurs:

> PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

My first thought was to avoid the deprecations by using `createMock`, but in fact phpunit `5.4` requires PHP `> 5.6`, so it is preferable to require a lower version of phpunit (`^4.1`).

Should be merged on master too.