### PR TITLE
Quote parameters in functional test configuration

### DIFF
--- a/Tests/Functional/config/config.yml
+++ b/Tests/Functional/config/config.yml
@@ -1,11 +1,11 @@
 framework:
     secret: test
     router:
-        resource: %kernel.root_dir%/config/routing.yml
+        resource: '%kernel.root_dir%/config/routing.yml'
 
 lexik_jwt_authentication:
-    private_key_path:   %kernel.root_dir%/var/private.pem
-    public_key_path:    %kernel.root_dir%/var/public.pem
+    private_key_path:   '%kernel.root_dir%/var/private.pem'
+    public_key_path:    '%kernel.root_dir%/var/public.pem'
     pass_phrase:        testing
 
 security:


### PR DESCRIPTION
Fix for:

> Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0: 6x