### PR TITLE
[Configuration] Make *_key_path config options not mandatory

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,10 +24,18 @@ class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('private_key_path')
-                    ->cannotBeEmpty()
+                    ->defaultNull()
+                    ->validate()
+                    ->ifString()
+                        ->then(self::validateKeyPath())
+                    ->end()
                 ->end()
                 ->scalarNode('public_key_path')
-                    ->cannotBeEmpty()
+                    ->defaultNull()
+                    ->validate()
+                    ->ifString()
+                        ->then(self::validateKeyPath())
+                    ->end()
                 ->end()
                 ->scalarNode('pass_phrase')
                     ->defaultValue('')
@@ -58,5 +66,16 @@ class Configuration implements ConfigurationInterface
             ->end();
 
         return $treeBuilder;
+    }
+
+    private static function validateKeyPath()
+    {
+        return function ($path) {
+            if (!is_file($path) || !is_readable($path)) {
+                throw new \InvalidArgumentException(sprintf('The file "%s" doesn\'t exist or is not readable.%sIf the configured encoder doesn\'t need this to be configured, please don\'t set this option or leave it null.', $path, PHP_EOL));
+            }
+
+            return $path;
+        };
     }
 }

--- a/Services/KeyLoader/AbstractKeyLoader.php
+++ b/Services/KeyLoader/AbstractKeyLoader.php
@@ -9,6 +9,9 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader;
  */
 abstract class AbstractKeyLoader implements KeyLoaderInterface
 {
+    const TYPE_PUBLIC  = 'public';
+    const TYPE_PRIVATE = 'private';
+
     /**
      * @var string
      */
@@ -55,27 +58,26 @@ abstract class AbstractKeyLoader implements KeyLoaderInterface
      */
     protected function getKeyPath($type)
     {
-        if ('public' === $type) {
-            return $this->publicKey;
+        if (!in_array($type, [self::TYPE_PUBLIC, self::TYPE_PRIVATE])) {
+            throw new \InvalidArgumentException(sprintf('The key type must be "public" or "private", "%s" given.', $type));
         }
 
-        if ('private' === $type) {
-            return $this->privateKey;
+        $path = null;
+
+        if (self::TYPE_PUBLIC === $type) {
+            $path = $this->publicKey;
         }
 
-        throw new \InvalidArgumentException(sprintf('The key type must be "public" or "private", "%s" given.', $type));
-    }
+        if (self::TYPE_PRIVATE === $type) {
+            $path = $this->privateKey;
+        }
 
-    /**
-     * @param string $type The key type
-     * @param string $path The key path
-     *
-     * @throws \RuntimeException
-     */
-    protected function createUnreadableKeyException($type, $path)
-    {
-        return new \RuntimeException(
-            sprintf('%s key "%s" does not exist or is not readable. Did you correctly set the "lexik_jwt_authentication.jwt_%s_key_path" config option?', ucfirst($type), $path, $type)
-        );
+        if (!is_file($path) || !is_readable($path)) {
+            throw new \RuntimeException(
+                sprintf('%s key "%s" does not exist or is not readable. Did you correctly set the "lexik_jwt_authentication.jwt_%s_key_path" config option?', ucfirst($type), $path, $type)
+            );
+        }
+
+        return $path;
     }
 }

--- a/Services/KeyLoader/OpenSSLKeyLoader.php
+++ b/Services/KeyLoader/OpenSSLKeyLoader.php
@@ -17,16 +17,11 @@ class OpenSSLKeyLoader extends AbstractKeyLoader
      */
     public function loadKey($type)
     {
-        $path = $this->getKeyPath($type);
-
-        if (!file_exists($path) || !is_readable($path)) {
-            throw $this->createUnreadableKeyException($type, $path);
-        }
-
+        $path         = $this->getKeyPath($type);
         $encryptedKey = file_get_contents($path);
         $key          = call_user_func_array(
             sprintf('openssl_pkey_get_%s', $type),
-            $type == 'private' ? [$encryptedKey, $this->getPassphrase()] : [$encryptedKey]
+            self::TYPE_PRIVATE == $type ? [$encryptedKey, $this->getPassphrase()] : [$encryptedKey]
         );
 
         if (!$key) {

--- a/Services/KeyLoader/SecLibKeyLoader.php
+++ b/Services/KeyLoader/SecLibKeyLoader.php
@@ -16,12 +16,6 @@ class SecLibKeyLoader extends AbstractKeyLoader
      */
     public function loadKey($type)
     {
-        $path = $this->getKeyPath($type);
-
-        if (!file_exists($path) || !is_readable($path)) {
-            throw $this->createUnreadableKeyException($type, $path);
-        }
-
-        return file_get_contents($path);
+        return file_get_contents($this->getKeyPath($type));
     }
 }


### PR DESCRIPTION
Since we want to integrate different bridges of JW* libraries, the `*_key_path` options should not be mandatory anymore, because some of their libraries (especially https://github.com/spomky-labs/lexik-jose-bridge) doesn't need this to be configured.

@Spomky, you worked on this in #195 (partially), sorry for that, we will profit of this change to perform some checks (key files existence) via config validation. Let me know what do you think.