### PR TITLE
Remove deprecated request args

### DIFF
--- a/Event/AuthenticationFailureEvent.php
+++ b/Event/AuthenticationFailureEvent.php
@@ -3,7 +3,6 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
@@ -16,13 +15,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 class AuthenticationFailureEvent extends Event
 {
     /**
-     * @var Request
-     *
-     * @deprecated since 1.7, removed in 2.0
-     */
-    protected $request;
-
-    /**
      * @var AuthenticationException
      */
     protected $exception;
@@ -33,34 +25,13 @@ class AuthenticationFailureEvent extends Event
     protected $response;
 
     /**
-     * @param Request|null            $request   Deprecated
      * @param AuthenticationException $exception
      * @param Response                $response
      */
-    public function __construct(Request $request = null, AuthenticationException $exception, Response $response)
+    public function __construct(AuthenticationException $exception, Response $response)
     {
-        if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Passing a Request instance as first argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
-
-            $this->request = $request;
-        }
-
         $this->exception = $exception;
         $this->response  = $response;
-    }
-
-    /**
-     * @deprecated since 1.7, removed in 2.0
-     *
-     * @return Request
-     */
-    public function getRequest()
-    {
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse  Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
-        }
-
-        return $this->request;
     }
 
     /**

--- a/Event/AuthenticationSuccessEvent.php
+++ b/Event/AuthenticationSuccessEvent.php
@@ -3,7 +3,6 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -25,13 +24,6 @@ class AuthenticationSuccessEvent extends Event
     protected $user;
 
     /**
-     * @var Request
-     *
-     * @deprecated since 1.7, removed in 2.0
-     */
-    protected $request;
-
-    /**
      * @var Response
      */
     protected $response;
@@ -39,20 +31,12 @@ class AuthenticationSuccessEvent extends Event
     /**
      * @param array         $data
      * @param UserInterface $user
-     * @param Request|null  $request  Deprecated
      * @param Response      $response
      */
-    public function __construct(array $data, UserInterface $user, Request $request = null, Response $response)
+    public function __construct(array $data, UserInterface $user, Response $response)
     {
-        if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Passing a Request instance as first argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
-
-            $this->request = $request;
-        }
-
         $this->data     = $data;
         $this->user     = $user;
-        $this->request  = $request;
         $this->response = $response;
     }
 
@@ -78,20 +62,6 @@ class AuthenticationSuccessEvent extends Event
     public function getUser()
     {
         return $this->user;
-    }
-
-    /**
-     * @deprecated since 1.7, removed in 2.0
-     *
-     * @return Request
-     */
-    public function getRequest()
-    {
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse  Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
-        }
-
-        return $this->request;
     }
 
     /**

--- a/Event/JWTCreatedEvent.php
+++ b/Event/JWTCreatedEvent.php
@@ -3,7 +3,6 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -22,25 +21,11 @@ class JWTCreatedEvent extends Event
     protected $user;
 
     /**
-     * @var Request
-     *
-     * @deprecated since 1.7, removed in 2.0
-     */
-    protected $request;
-
-    /**
      * @param array         $data
      * @param UserInterface $user
-     * @param Request|null  $request Deprecated
      */
-    public function __construct(array $data, UserInterface $user, Request $request = null)
+    public function __construct(array $data, UserInterface $user)
     {
-        if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Passing a Request instance as first argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
-
-            $this->request = $request;
-        }
-
         $this->data = $data;
         $this->user = $user;
     }
@@ -67,19 +52,5 @@ class JWTCreatedEvent extends Event
     public function getUser()
     {
         return $this->user;
-    }
-
-    /**
-     * @deprecated since 1.7, removed in 2.0
-     *
-     * @return Request
-     */
-    public function getRequest()
-    {
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse  Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
-        }
-
-        return $this->request;
     }
 }

--- a/Event/JWTDecodedEvent.php
+++ b/Event/JWTDecodedEvent.php
@@ -3,7 +3,6 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * JWTDecodedEvent.
@@ -18,29 +17,15 @@ class JWTDecodedEvent extends Event
     protected $payload;
 
     /**
-     * @var Request
-     *
-     * @deprecated since 1.7, removed in 2.0
-     */
-    protected $request;
-
-    /**
      * @var bool
      */
     protected $isValid;
 
     /**
-     * @param array        $payload
-     * @param Request|null $request Deprecated
+     * @param array $payload
      */
-    public function __construct(array $payload, Request $request = null)
+    public function __construct(array $payload)
     {
-        if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Passing a Request instance as first argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
-
-            $this->request = $request;
-        }
-
         $this->payload = $payload;
         $this->isValid = true;
     }
@@ -51,20 +36,6 @@ class JWTDecodedEvent extends Event
     public function getPayload()
     {
         return $this->payload;
-    }
-
-    /**
-     * @deprecated since 1.7, removed in 2.0
-     *
-     * @return Request
-     */
-    public function getRequest()
-    {
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse  Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
-        }
-
-        return $this->request;
     }
 
     /**

--- a/Event/JWTFailureEventInterface.php
+++ b/Event/JWTFailureEventInterface.php
@@ -2,7 +2,6 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
@@ -14,23 +13,24 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 interface JWTFailureEventInterface
 {
     /**
+     * Gets the response that will be returned after dispatching a
+     * {@link JWTFailureEventInterface} implementation.
+     *
      * @return Response
      */
     public function getResponse();
 
     /**
-     * @deprecated since 1.7, removed in 2.0
+     * Gets the tied AuthenticationException object.
      *
-     * @return Request
-     */
-    public function getRequest();
-
-    /**
      * @return AuthenticationException
      */
     public function getException();
 
     /**
+     * Calling this allows to return a custom Response immediately after
+     * the corresponding implementation of this event is dispatched.
+     *
      * @param Response $response
      */
     public function setResponse(Response $response);

--- a/Event/JWTNotFoundEvent.php
+++ b/Event/JWTNotFoundEvent.php
@@ -2,7 +2,6 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
@@ -15,18 +14,11 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 class JWTNotFoundEvent extends AuthenticationFailureEvent implements JWTFailureEventInterface
 {
     /**
-     * @param Request|null                 $request   Deprecated
      * @param AuthenticationException|null $exception
      * @param Response|null                $response
      */
-    public function __construct(Request $request = null, AuthenticationException $exception = null, Response $response = null)
+    public function __construct(AuthenticationException $exception = null, Response $response = null)
     {
-        if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Passing a Request instance as first argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
-
-            $this->request = $request;
-        }
-
         $this->exception = $exception;
         $this->response  = $response;
     }

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -124,7 +124,7 @@ class JWTListener implements ListenerInterface
     /**
      * @param Request $request
      *
-     * @return boolean|string
+     * @return string
      */
     protected function getRequestToken(Request $request)
     {

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -70,12 +70,10 @@ class JWTListener implements ListenerInterface
      */
     public function handle(GetResponseEvent $event)
     {
-        // Ensure backward compatibility for Symfony < 2.8
-        $request         = $event->getRequest();
-        $hasRequestStack = class_exists('Symfony\Component\HttpFoundation\RequestStack');
+        $requestToken = $this->getRequestToken($event->getRequest());
 
-        if (!$requestToken = $this->getRequestToken($request)) {
-            $jwtNotFoundEvent = new JWTNotFoundEvent($hasRequestStack ? null : $request);
+        if (null === $requestToken) {
+            $jwtNotFoundEvent = new JWTNotFoundEvent();
             $this->dispatcher->dispatch(Events::JWT_NOT_FOUND, $jwtNotFoundEvent);
 
             if ($response = $jwtNotFoundEvent->getResponse()) {
@@ -100,7 +98,7 @@ class JWTListener implements ListenerInterface
 
             $response = new JWTAuthenticationFailureResponse($failed->getMessage());
 
-            $jwtInvalidEvent = new JWTInvalidEvent($hasRequestStack ? null : $request, $failed, $response);
+            $jwtInvalidEvent = new JWTInvalidEvent($failed, $response);
             $this->dispatcher->dispatch(Events::JWT_INVALID, $jwtInvalidEvent);
 
             $event->setResponse($jwtInvalidEvent->getResponse());
@@ -136,7 +134,5 @@ class JWTListener implements ListenerInterface
                 return $token;
             }
         }
-
-        return false;
     }
 }

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -35,7 +35,7 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        $event = new AuthenticationFailureEvent(null, $exception, new JWTAuthenticationFailureResponse());
+        $event = new AuthenticationFailureEvent($exception, new JWTAuthenticationFailureResponse());
 
         $this->dispatcher->dispatch(Events::AUTHENTICATION_FAILURE, $event);
 

--- a/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -46,7 +46,8 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
         $user     = $token->getUser();
         $jwt      = $this->jwtManager->create($user);
         $response = new JWTAuthenticationSuccessResponse($jwt);
-        $event    = new AuthenticationSuccessEvent(['token' => $jwt], $user, null, $response);
+        $event    = new AuthenticationSuccessEvent(['token' => $jwt], $user, $response);
+
         $this->dispatcher->dispatch(Events::AUTHENTICATION_SUCCESS, $event);
         $response->setData($event->getData());
 

--- a/Tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
+++ b/Tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
@@ -17,7 +17,10 @@ class AuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnAuthenticationFailure()
     {
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this
+            ->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $handler  = new AuthenticationFailureHandler($dispatcher);
         $response = $handler->onAuthenticationFailure($this->getRequest(), $this->getAuthenticationException());

--- a/Tests/Services/JWTManagerTest.php
+++ b/Tests/Services/JWTManagerTest.php
@@ -43,7 +43,7 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
             ->method('encode')
             ->willReturn('secrettoken');
 
-        $manager = new JWTManager($encoder, $dispatcher, $this->getMockedRequestStack(), 3600);
+        $manager = new JWTManager($encoder, $dispatcher, 3600);
         $this->assertEquals('secrettoken', $manager->create(new User('user', 'password')));
     }
 
@@ -67,7 +67,7 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
             ->method('decode')
             ->willReturn(['foo' => 'bar']);
 
-        $manager = new JWTManager($encoder, $dispatcher, $this->getMockedRequestStack(), 3600);
+        $manager = new JWTManager($encoder, $dispatcher, 3600);
         $this->assertEquals(['foo' => 'bar'], $manager->decode($this->getJWTUserTokenMock()));
     }
 
@@ -99,7 +99,7 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
             ->method('encode')
             ->willReturn('secrettoken');
 
-        $manager = new JWTManager($encoder, $dispatcher, $this->getMockedRequestStack(), 3600);
+        $manager = new JWTManager($encoder, $dispatcher, 3600);
         $manager->setUserIdentityField('email');
         $this->assertEquals('secrettoken', $manager->create(new CustomUser('user', 'password', 'victuxbb@gmail.com')));
     }
@@ -142,19 +142,5 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
             ->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
             ->disableOriginalConstructor()
             ->getMock();
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function getMockedRequestStack()
-    {
-        $requestStack = $this->getMock('Symfony\Component\HttpFoundation\RequestStack', []);
-        $requestStack
-            ->expects($this->any())
-            ->method('getMasterRequest')
-            ->willReturn($this->getMock('Symfony\Component\HttpFoundation\Request'));
-
-        return $requestStack;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes

This totally remove the ability of injecting request instances in Event classes, plus there is no more need of injecting the `@request_stack` service into the `JWTManager` class.
