### PR TITLE
Fix unmerged path in services.xml after #201

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,7 +13,6 @@
         <service id="lexik_jwt_authentication.jwt_manager" class="Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager">
             <argument type="service" id="lexik_jwt_authentication.encoder"/>
             <argument type="service" id="event_dispatcher"/>
-            <argument type="service" id="request_stack"/>
             <argument>%lexik_jwt_authentication.token_ttl%</argument>
             <call method="setUserIdentityField">
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix | yes
| Feature | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

This fixes a big bug introduced in #201 because of an unmerged path (`services.xml`). It caused that a bad value was passed as token ttl, so it is unable to decode any token.
