### PR TITLE
Refactor TokenExtractors loading for easy overriding

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -63,11 +64,72 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('username')
                     ->cannotBeEmpty()
                 ->end()
+                ->append(self::getTokenExtractorsNode())
             ->end();
 
         return $treeBuilder;
     }
 
+    public static function addTokenExtractors(ArrayNodeDefinition $node)
+    {
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('authorization_header')
+                ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')
+                            ->defaultTrue()
+                        ->end()
+                        ->scalarNode('prefix')
+                            ->defaultValue('Bearer')
+                        ->end()
+                        ->scalarNode('name')
+                            ->defaultValue('Authorization')
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('cookie')
+                ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')
+                            ->defaultFalse()
+                        ->end()
+                        ->scalarNode('name')
+                            ->defaultValue('BEARER')
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('query_parameter')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')
+                            ->defaultFalse()
+                        ->end()
+                        ->scalarNode('name')
+                            ->defaultValue('bearer')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * @return TreeBuilder
+     */
+    private static function getTokenExtractorsNode()
+    {
+        $builder = new TreeBuilder();
+        $node    = $builder->root('token_extractors');
+        self::addTokenExtractors($node);
+
+        return $node;
+    }
+
+    /**
+     * @return \Closure
+     */
     private static function validateKeyPath()
     {
         return function ($path) {

--- a/DependencyInjection/Security/Factory/JWTFactory.php
+++ b/DependencyInjection/Security/Factory/JWTFactory.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory;
 
+use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Configuration;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -94,44 +95,10 @@ class JWTFactory implements SecurityFactoryInterface
      */
     public function addConfiguration(NodeDefinition $node)
     {
+        Configuration::addTokenExtractors($node);
+
         $node
             ->children()
-                ->arrayNode('authorization_header')
-                ->addDefaultsIfNotSet()
-                    ->children()
-                        ->booleanNode('enabled')
-                            ->defaultTrue()
-                        ->end()
-                        ->scalarNode('prefix')
-                            ->defaultValue('Bearer')
-                        ->end()
-                        ->scalarNode('name')
-                            ->defaultValue('Authorization')
-                        ->end()
-                    ->end()
-                ->end()
-                ->arrayNode('cookie')
-                ->addDefaultsIfNotSet()
-                    ->children()
-                        ->booleanNode('enabled')
-                            ->defaultFalse()
-                        ->end()
-                        ->scalarNode('name')
-                            ->defaultValue('BEARER')
-                        ->end()
-                    ->end()
-                ->end()
-                ->arrayNode('query_parameter')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->booleanNode('enabled')
-                            ->defaultFalse()
-                        ->end()
-                        ->scalarNode('name')
-                            ->defaultValue('bearer')
-                        ->end()
-                    ->end()
-                ->end()
                 ->booleanNode('throw_exceptions')
                     ->defaultFalse()
                 ->end()

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -58,17 +58,28 @@
                 <argument type="service" id="event_dispatcher"/>
             </call>
         </service>
+        <!-- Token Extractor Map -->
+        <service id="lexik_jwt_authentication.token_extractor_map" class="Lexik\Bundle\JWTAuthenticationBundle\Services\TokenExtractorMap" public="false">
+            <argument type="collection" /> <!-- The extractor services -->
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+        <!-- Chain Token Extractor -->
+        <service id="lexik_jwt_authentication.extractor.chain_extractor" class="Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\ChainTokenExtractor" public="false">
+            <argument type="service" id="lexik_jwt_authentication.token_extractor_map" />
+        </service>
         <!-- Authorization Header Token Extractor -->
-        <service id="lexik_jwt_authentication.extractor.authorization_header_extractor" class="Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\AuthorizationHeaderTokenExtractor" public="false">
+        <service id="lexik_jwt_authentication.extractor.authorization_header_extractor" class="Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\AuthorizationHeaderTokenExtractor">
             <argument /> <!-- Header Value Prefix -->
             <argument /> <!-- Header Value Name -->
         </service>
         <!-- Query Parameter Token Extractor -->
-        <service id="lexik_jwt_authentication.extractor.query_parameter_extractor" class="Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\QueryParameterTokenExtractor" public="false">
+        <service id="lexik_jwt_authentication.extractor.query_parameter_extractor" class="Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\QueryParameterTokenExtractor">
             <argument /> <!-- Parameter Name -->
         </service>
         <!-- Cookie Token Extractor -->
-        <service id="lexik_jwt_authentication.extractor.cookie_extractor" class="Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\CookieTokenExtractor" public="false">
+        <service id="lexik_jwt_authentication.extractor.cookie_extractor" class="Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\CookieTokenExtractor">
             <argument /> <!-- Name -->
         </service>
         <!-- JWT Security Authentication Entry Point -->

--- a/Services/TokenExtractorMap.php
+++ b/Services/TokenExtractorMap.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Services;
+
+use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * TokenExtractorMap is a map of services implementing {@link TokenExtractorInterface}
+ * that can be loaded on demand.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class TokenExtractorMap implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var array
+     */
+    private $map = [];
+
+    /**
+     * @param array $map An array of service ids implementing {@link TokenExtractorInterface}
+     */
+    public function __construct(array $map = [])
+    {
+        $this->map = $map;
+    }
+
+    /**
+     * Adds a new token extractor to the map.
+     *
+     * @param string $id The service id
+     */
+    public function add($id)
+    {
+        if (in_array($id, $this->map)) {
+            return;
+        }
+
+        if (false === $this->container->has($id)) {
+            throw new \InvalidArgumentException(sprintf('The first argument of "%s()" must be a valid service identifier refering to a "%s" implementation, "%s" given.', __METHOD__, TokenExtractorInterface::class, $id));
+        }
+
+        $this->map[] = $id;
+    }
+
+    /**
+     * Removes a token extractor from the map.
+     *
+     * Note: This easily disables a token extractor, the service will be
+     * removed from the map of the current instance but not definitely, the
+     * map will be entirely resetted at the next instance. For overriding
+     * the default map, see the "@lexik_jwt_authentication.token_extractor_map"
+     * service.
+     *
+     * @param string $id The token extractor service id
+     */
+    public function remove($id)
+    {
+        if ($key = array_search($id, $this->map)) {
+            unset($this->map[$key]);
+        }
+    }
+
+    /**
+     * Loads the mapped token extractors.
+     *
+     * An extractor is initialized only if we really need it (at
+     * the corresponding iteration).
+     *
+     * @return \Generator The generated TokenExtractorInterface implementations
+     */
+    public function loadExtractors()
+    {
+        foreach ($this->map as $id) {
+            $extractor = $this->container->get($id);
+
+            if ($extractor instanceof TokenExtractorInterface) {
+                yield $extractor;
+            }
+        }
+    }
+}

--- a/Tests/Services/TokenExtractorMapTest.php
+++ b/Tests/Services/TokenExtractorMapTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Services;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Services\TokenExtractorMap;
+use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * TokenExtractorMap Test.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class TokenExtractorMapTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLoadExtractors()
+    {
+        $extractors = [$this->getTokenExtractorMock(), $this->getTokenExtractorMock()];
+        $container  = $this->getContainerMock();
+        $container
+            ->expects($this->at(0))
+            ->method('get')
+            ->with('foo_extractor')
+            ->willReturn($extractors[0]);
+        $container
+            ->expects($this->at(1))
+            ->method('get')
+            ->with('bar_extractor')
+            ->willReturn($extractors[1]);
+
+        $map = new TokenExtractorMap(['foo_extractor', 'bar_extractor']);
+        $map->setContainer($container);
+
+        $loadedExtractors = [];
+        foreach ($map->loadExtractors() as $extractor) {
+            $loadedExtractors[] = $extractor;
+        }
+
+        $this->assertSame($extractors, $loadedExtractors);
+    }
+
+    public function testAdd()
+    {
+        $container = $this->getContainerMock();
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('extra')
+            ->willReturn(true);
+
+        $map = new TokenExtractorMap(['first']);
+        $map->setContainer($container);
+        $map->add('extra');
+
+        $this->assertAttributeSame(['first', 'extra'], 'map', $map);
+    }
+
+    public function testRemove()
+    {
+        $map = new TokenExtractorMap(['first', 'second']);
+        $map->remove('second');
+
+        $this->assertAttributeSame(['first'], 'map', $map);
+    }
+
+    private function getContainerMock()
+    {
+        return $this
+            ->getMockBuilder(ContainerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    private function getTokenExtractorMock()
+    {
+        return $this
+            ->getMockBuilder(TokenExtractorInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/Tests/TokenExtractor/ChainTokenExtractorTest.php
+++ b/Tests/TokenExtractor/ChainTokenExtractorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\TokenExtractor;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Services\TokenExtractorMap;
+use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\ChainTokenExtractor;
+use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * AuthorizationHeaderTokenExtractorTest.
+ *
+ * @author Nicolas Cabot <n.cabot@lexik.fr>
+ */
+class ChainTokenExtractorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExtract()
+    {
+        $request = new Request();
+
+        $tokenExtractorMap = $this
+            ->getMockBuilder(TokenExtractorMap::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $tokenExtractorMap
+            ->expects($this->once())
+            ->method('loadExtractors')
+            ->willReturn($this->generateTokenExtractorMocks([false, false, 'dummy']));
+
+        $chainExtractor = new ChainTokenExtractor($tokenExtractorMap);
+
+        $this->assertEquals('dummy', $chainExtractor->extract($request));
+    }
+
+    public function testGetMap()
+    {
+        $tokenExtractorMap = $this
+            ->getMockBuilder(TokenExtractorMap::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->assertSame($tokenExtractorMap, (new ChainTokenExtractor($tokenExtractorMap))->getMap());
+    }
+
+    private function getTokenExtractorMock($returnValue)
+    {
+        $extractor = $this
+            ->getMockBuilder(TokenExtractorInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $extractor
+            ->expects($this->once())
+            ->method('extract')
+            ->with($this->isInstanceOf(Request::class))
+            ->willReturn($returnValue);
+
+        return $extractor;
+    }
+
+    private function generateTokenExtractorMocks($returnValues)
+    {
+        foreach ($returnValues as $value) {
+            yield $this->getTokenExtractorMock($value);
+        }
+    }
+}

--- a/TokenExtractor/AuthorizationHeaderTokenExtractor.php
+++ b/TokenExtractor/AuthorizationHeaderTokenExtractor.php
@@ -32,9 +32,7 @@ class AuthorizationHeaderTokenExtractor implements TokenExtractorInterface
     }
 
     /**
-     * @param Request $request
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function extract(Request $request)
     {

--- a/TokenExtractor/ChainTokenExtractor.php
+++ b/TokenExtractor/ChainTokenExtractor.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Services\TokenExtractorMap;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * ChainTokenExtractor is the class responsible of extracting a JWT token
+ * from a {@link Request} object using all mapped token extractors.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class ChainTokenExtractor implements TokenExtractorInterface
+{
+    /**
+     * @var TokenExtractorMap
+     */
+    private $map;
+
+    /**
+     * @param TokenExtractorMap $map
+     */
+    public function __construct(TokenExtractorMap $map)
+    {
+        $this->map = $map;
+    }
+
+    /**
+     * Iterates over the token extractors map calling {@see extract()}
+     * until a token is found.
+     *
+     * {@inheritdoc}
+     */
+    public function extract(Request $request)
+    {
+        foreach ($this->map->loadExtractors() as $extractor) {
+            if ($token = $extractor->extract($request)) {
+                return $token;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return TokenExtractorMap
+     */
+    public function getMap()
+    {
+        return $this->map;
+    }
+}

--- a/TokenExtractor/CookieTokenExtractor.php
+++ b/TokenExtractor/CookieTokenExtractor.php
@@ -25,16 +25,10 @@ class CookieTokenExtractor implements TokenExtractorInterface
     }
 
     /**
-     * @param Request $request
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function extract(Request $request)
     {
-        if (!$request->cookies->has($this->name)) {
-            return false;
-        }
-
-        return $request->cookies->get($this->name);
+        return $request->cookies->get($this->name, false);
     }
 }

--- a/TokenExtractor/QueryParameterTokenExtractor.php
+++ b/TokenExtractor/QueryParameterTokenExtractor.php
@@ -25,9 +25,7 @@ class QueryParameterTokenExtractor implements TokenExtractorInterface
     }
 
     /**
-     * @param Request $request
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function extract(Request $request)
     {

--- a/TokenExtractor/TokenExtractorInterface.php
+++ b/TokenExtractor/TokenExtractorInterface.php
@@ -14,7 +14,7 @@ interface TokenExtractorInterface
     /**
      * @param Request $request
      *
-     * @return string
+     * @return string|false
      */
     public function extract(Request $request);
 }


### PR DESCRIPTION
Per title.
This was first included in #184, I split it here for readability.

---------

- [x] Introduce TokenExtractorMap for lazy load extractors
- [x] ChainTokenExtractor decoupling extracting logic from security classes
- [x] Add 'token_extractors' configuration path