### PR TITLE
Add more flexibility in token extractors configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ For a diff between two versions https://github.com/lexik/LexikJWTAuthenticationB
 
 ## [2.0](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/2.0)
 
+* feature [\#218](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/218) Add more flexibility in token extractors configuration ([chalasr](https://github.com/chalasr))
+
+* feature [\#217](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/217) Refactor TokenExtractors loading for easy overriding ([chalasr](https://github.com/chalasr))
+
 * feature [\#202](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/202) Exceptions simplified ([Spomky](https://github.com/Spomky))
 
 * feature [\#201](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/201) Remove deprecated request injections ([chalasr](https://github.com/chalasr))

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -61,7 +61,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('username')
                     ->cannotBeEmpty()
                 ->end()
-                ->append($this->getTokenExtractorsNodeBuilder())
+                ->append($this->getTokenExtractorsNode())
             ->end();
 
         return $treeBuilder;
@@ -70,7 +70,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @return TreeBuilder
      */
-    private function getTokenExtractorsNodeBuilder()
+    private function getTokenExtractorsNode()
     {
         $builder = new TreeBuilder();
         $node    = $builder->root('token_extractors');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -6,9 +6,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files.
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ * LexikJWTAuthenticationBundle Configuration.
  */
 class Configuration implements ConfigurationInterface
 {
@@ -63,7 +61,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('username')
                     ->cannotBeEmpty()
                 ->end()
-                ->append(self::getTokenExtractorsNode())
+                ->append($this->getTokenExtractorsNodeBuilder())
             ->end();
 
         return $treeBuilder;
@@ -72,7 +70,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @return TreeBuilder
      */
-    private static function getTokenExtractorsNode()
+    private function getTokenExtractorsNodeBuilder()
     {
         $builder = new TreeBuilder();
         $node    = $builder->root('token_extractors');
@@ -82,10 +80,8 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('authorization_header')
                 ->addDefaultsIfNotSet()
+                ->canBeDisabled()
                     ->children()
-                        ->booleanNode('enabled')
-                            ->defaultTrue()
-                        ->end()
                         ->scalarNode('prefix')
                             ->defaultValue('Bearer')
                         ->end()
@@ -96,10 +92,8 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('cookie')
                 ->addDefaultsIfNotSet()
+                ->canBeEnabled()
                     ->children()
-                        ->booleanNode('enabled')
-                            ->defaultFalse()
-                        ->end()
                         ->scalarNode('name')
                             ->defaultValue('BEARER')
                         ->end()
@@ -107,10 +101,8 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('query_parameter')
                     ->addDefaultsIfNotSet()
+                    ->canBeEnabled()
                     ->children()
-                        ->booleanNode('enabled')
-                            ->defaultFalse()
-                        ->end()
                         ->scalarNode('name')
                             ->defaultValue('bearer')
                         ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,7 +2,6 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -70,8 +69,14 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    public static function addTokenExtractors(ArrayNodeDefinition $node)
+    /**
+     * @return TreeBuilder
+     */
+    private static function getTokenExtractorsNode()
     {
+        $builder = new TreeBuilder();
+        $node    = $builder->root('token_extractors');
+
         $node
             ->addDefaultsIfNotSet()
             ->children()
@@ -113,16 +118,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
-    }
-
-    /**
-     * @return TreeBuilder
-     */
-    private static function getTokenExtractorsNode()
-    {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('token_extractors');
-        self::addTokenExtractors($node);
 
         return $node;
     }

--- a/DependencyInjection/Security/Factory/JWTFactory.php
+++ b/DependencyInjection/Security/Factory/JWTFactory.php
@@ -2,7 +2,6 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory;
 
-use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Configuration;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -95,10 +94,38 @@ class JWTFactory implements SecurityFactoryInterface
      */
     public function addConfiguration(NodeDefinition $node)
     {
-        Configuration::addTokenExtractors($node);
-
         $node
             ->children()
+                ->arrayNode('authorization_header')
+                ->addDefaultsIfNotSet()
+                ->canBeDisabled()
+                    ->children()
+                        ->scalarNode('prefix')
+                            ->defaultValue('Bearer')
+                        ->end()
+                        ->scalarNode('name')
+                            ->defaultValue('Authorization')
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('cookie')
+                ->addDefaultsIfNotSet()
+                ->canBeEnabled()
+                    ->children()
+                        ->scalarNode('name')
+                            ->defaultValue('BEARER')
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('query_parameter')
+                ->canBeEnabled()
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('name')
+                            ->defaultValue('bearer')
+                        ->end()
+                    ->end()
+                ->end()
                 ->booleanNode('throw_exceptions')
                     ->defaultFalse()
                 ->end()


### PR DESCRIPTION
This makes use of the useful `canBeDisabled()`/`canBeEnabled()` methods of the Config' `ArrayNodeDefinition`.

From userland pov, the change is not that big but adds some flexibility.

```yaml
authorization_header: ~     # array('enabled' => true, 'name' => 'Authorization', 'prefix' => 'Bearer')
authorization_header: true  # array('enabled' => true, ...)
authorization_header: false # array('enabled' => false, ...)
```

Same for the `query_parameter` and `cookie` ones except that they are default disabled (when they are not set at all).