### PR TITLE
Make the default encoder service public

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,7 +6,7 @@
 
     <services>
         <!--  Default JWT Encoder / Decoder -->
-        <service id="lexik_jwt_authentication.encoder.default" class="Lexik\Bundle\JWTAuthenticationBundle\Encoder\DefaultEncoder" public="false">
+        <service id="lexik_jwt_authentication.encoder.default" class="Lexik\Bundle\JWTAuthenticationBundle\Encoder\DefaultEncoder">
             <argument type="service" id="lexik_jwt_authentication.jws_provider"/>
         </service>
         <!-- JWT Manager / Default implementation -->


### PR DESCRIPTION
| Q             | A    |
|---------------|------|
| Bug fix?      | no  |
| New feature?  | no |
| BC breaks?    | no  |
| Deprecations | no |
| Fixed tickets | ~ |
| Tests pass?   | yes  |

It can be useful to get the service from a container, plus it would be a too big BC break to privatise it in 2.0.
