### PR TITLE
TTL scaled down

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,7 +41,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('')
                 ->end()
                 ->scalarNode('token_ttl')
-                    ->defaultValue(86400)
+                    ->defaultValue(3600)
                 ->end()
                 ->arrayNode('encoder')
                     ->addDefaultsIfNotSet()

--- a/Resources/doc/1-configuration-reference.md
+++ b/Resources/doc/1-configuration-reference.md
@@ -17,7 +17,7 @@ lexik_jwt_authentication:
     # ssh key pass phrase
     pass_phrase:         ''
     # token ttl
-    token_ttl:           86400
+    token_ttl:           3600
     # key under which the user identity will be stored in the token payload
     user_identity_field: username
 

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -55,7 +55,7 @@ Configure your `parameters.yml.dist` :
     jwt_private_key_path: %kernel.root_dir%/../var/jwt/private.pem   # ssh private key path
     jwt_public_key_path:  %kernel.root_dir%/../var/jwt/public.pem    # ssh public key path
     jwt_key_pass_phrase:  ''                                         # ssh key pass phrase
-    jwt_token_ttl:        86400
+    jwt_token_ttl:        3600
 ```
 
 Configure your `security.yml` :
@@ -113,7 +113,7 @@ A classical form_login on an anonymously accessible firewall will do perfect.
 Just set the provided `lexik_jwt_authentication.handler.authentication_success` service as success handler to
 generate the token and send it as part of a json response body.
 
-Store it (client side), the JWT is reusable until its ttl has expired (86400 seconds by default).
+Store it (client side), the JWT is reusable until its ttl has expired (3600 seconds by default).
 
 Note: You can test getting the token with a simple curl command like this:
 

--- a/Tests/Encoder/DefaultEncoderTest.php
+++ b/Tests/Encoder/DefaultEncoderTest.php
@@ -21,7 +21,7 @@ class DefaultEncoderTest extends \PHPUnit_Framework_TestCase
     {
         $payload     = [
             'username' => 'chalasr',
-            'exp'      => (new \DateTime('now'))->format('U') + 86400,
+            'exp'      => time() + 3600,
         ];
 
         $loadedJWS   = new LoadedJWS($payload, true);
@@ -94,7 +94,7 @@ class DefaultEncoderTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecodeFromExpiredPayload()
     {
-        $loadedJWS   = new LoadedJWS(['exp' => (new \DateTime('now'))->format('U') - 86400], true);
+        $loadedJWS   = new LoadedJWS(['exp' => time() - 3600], true);
         $jwsProvider = $this->getJWSProviderMock();
         $jwsProvider
             ->expects($this->once())

--- a/Tests/Signature/LoadedJWSTest.php
+++ b/Tests/Signature/LoadedJWSTest.php
@@ -18,7 +18,7 @@ final class LoadedJWSTest extends \PHPUnit_Framework_TestCase
     {
         $this->goodPayload = [
             'username' => 'chalasr',
-            'exp'      => (int) (new \DateTime('now'))->format('U') + 86400,
+            'exp'      => time() + 3600,
         ];
     }
 
@@ -52,7 +52,7 @@ final class LoadedJWSTest extends \PHPUnit_Framework_TestCase
     public function testVerifiedWithExpiredPayload()
     {
         $payload = $this->goodPayload;
-        $payload['exp'] -= 86400;
+        $payload['exp'] -= 3600;
 
         $jws = new LoadedJWS($payload, true);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no|
| BC breaks? | yes |
| Deprecations | no|
| Fixed tickets | no |
| Tests pass | yes |

86400 seconds (24 hrs) seem to be too high for a token TTL.
This commit reduces this value to 3600 seconds (1 hr).

1 hour should be enough for almost all use cases. If not, a bundle that
provides refresh token implementation will allow to issue another token
when it is expired.