### PR TITLE
Enhance naming

### DIFF
--- a/Services/JWSProvider.php
+++ b/Services/JWSProvider.php
@@ -30,28 +30,28 @@ class JWSProvider implements JWSProviderInterface
     /**
      * @var string
      */
-    private $encryptionAlgorithm;
+    private $signatureAlgorithm;
 
     /**
      * @param KeyLoaderInterface $keyLoader
      * @param string             $encryptionEngine
-     * @param string             $encryptionAlgorithm
+     * @param string             $signatureAlgorithm
      *
      * @throws \InvalidArgumentException If the given algorithm is not supported
      */
-    public function __construct(KeyLoaderInterface $keyLoader, $encryptionEngine, $encryptionAlgorithm)
+    public function __construct(KeyLoaderInterface $keyLoader, $encryptionEngine, $signatureAlgorithm)
     {
         $encryptionEngine = $encryptionEngine == 'openssl' ? 'OpenSSL' : 'SecLib';
 
-        if (!$this->isAlgorithmSupportedForEngine($encryptionEngine, $encryptionAlgorithm)) {
+        if (!$this->isAlgorithmSupportedForEngine($encryptionEngine, $signatureAlgorithm)) {
             throw new \InvalidArgumentException(
-                sprintf('The algorithm "%s" is not supported for %s', $encryptionAlgorithm, $encryptionEngine)
+                sprintf('The algorithm "%s" is not supported for %s', $signatureAlgorithm, $encryptionEngine)
             );
         }
 
-        $this->keyLoader           = $keyLoader;
-        $this->encryptionEngine    = $encryptionEngine;
-        $this->encryptionAlgorithm = $encryptionAlgorithm;
+        $this->keyLoader          = $keyLoader;
+        $this->encryptionEngine   = $encryptionEngine;
+        $this->signatureAlgorithm = $signatureAlgorithm;
     }
 
     /**
@@ -59,7 +59,7 @@ class JWSProvider implements JWSProviderInterface
      */
     public function create(array $payload)
     {
-        $jws = new JWS(['alg' => $this->encryptionAlgorithm], $this->encryptionEngine);
+        $jws = new JWS(['alg' => $this->signatureAlgorithm], $this->encryptionEngine);
 
         $jws->setPayload($payload);
         $jws->sign(
@@ -79,19 +79,19 @@ class JWSProvider implements JWSProviderInterface
 
         return new LoadedJWS(
             $jws->getPayload(),
-            $jws->verify($this->keyLoader->loadKey('public'), $this->encryptionAlgorithm)
+            $jws->verify($this->keyLoader->loadKey('public'), $this->signatureAlgorithm)
         );
     }
 
     /**
      * @param string $encryptionEngine
-     * @param string $encryptionAlgorithm
+     * @param string $signatureAlgorithm
      *
      * @return bool
      */
-    private function isAlgorithmSupportedForEngine($encryptionEngine, $encryptionAlgorithm)
+    private function isAlgorithmSupportedForEngine($encryptionEngine, $signatureAlgorithm)
     {
-        $signerClass = sprintf('Namshi\\JOSE\\Signer\\%s\\%s', $encryptionEngine, $encryptionAlgorithm);
+        $signerClass = sprintf('Namshi\\JOSE\\Signer\\%s\\%s', $encryptionEngine, $signatureAlgorithm);
 
         return class_exists($signerClass);
     }

--- a/Services/KeyLoader/KeyLoaderInterface.php
+++ b/Services/KeyLoader/KeyLoaderInterface.php
@@ -3,7 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader;
 
 /**
- * Interface for classes that are able to load SSL encryption keys.
+ * Interface for classes that are able to load crypto keys.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */

--- a/Services/KeyLoader/OpenSSLKeyLoader.php
+++ b/Services/KeyLoader/OpenSSLKeyLoader.php
@@ -3,7 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader;
 
 /**
- * Load config keys for the OpenSSL encryption engine.
+ * Load crypto keys for the OpenSSL encryption engine.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */

--- a/Services/KeyLoader/SecLibKeyLoader.php
+++ b/Services/KeyLoader/SecLibKeyLoader.php
@@ -3,7 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader;
 
 /**
- * Load config keys for the phpseclib encryption engine.
+ * Load crypto keys for the phpseclib encryption engine.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */

--- a/Tests/Functional/DependencyInjection/LexikJWTAuthenticationExtensionTest.php
+++ b/Tests/Functional/DependencyInjection/LexikJWTAuthenticationExtensionTest.php
@@ -24,7 +24,7 @@ class LexikJWTAuthenticationExtensionTest extends TestCase
         $container           = $kernel->getContainer();
         $encoderNamespace    = 'lexik_jwt_authentication.encoder';
         $encryptionEngine    = $container->getParameter($encoderNamespace.'.encryption_engine');
-        $encryptionAlgorithm = $container->getParameter($encoderNamespace.'.signature_algorithm');
+        $signatureAlgorithm  = $container->getParameter($encoderNamespace.'.signature_algorithm');
 
         /* @var PHPUnit_Framework_MockObject_MockObject */
         $jwsProviderMock = $this
@@ -32,7 +32,7 @@ class LexikJWTAuthenticationExtensionTest extends TestCase
             ->setConstructorArgs([
                 $container->get('lexik_jwt_authentication.key_loader'),
                 $encryptionEngine,
-                $encryptionAlgorithm,
+                $signatureAlgorithm,
             ])
             ->getMock();
 
@@ -50,8 +50,8 @@ class LexikJWTAuthenticationExtensionTest extends TestCase
 
         // The configured algorithm is the one used by the service
         $this->assertAttributeEquals(
-            $encryptionAlgorithm,
-            'encryptionAlgorithm',
+            $signatureAlgorithm,
+            'signatureAlgorithm',
             $jwsProviderMock
         );
     }

--- a/Tests/Services/JWSProviderTest.php
+++ b/Tests/Services/JWSProviderTest.php
@@ -104,7 +104,7 @@ vwIDAQAB
      * @expectedException        \InvalidArgumentException
      * @expectedExceptionMessage The algorithm "wrongAlgorithm" is not supported
      */
-    public function testInvalidEncryptionAlgorithm()
+    public function testInvalidsignatureAlgorithm()
     {
         new JWSProvider($this->getKeyLoaderMock(), 'openssl', 'wrongAlgorithm');
     }


### PR DESCRIPTION
Next to #195 where we changed `encryption_algorithm` to `signature_algorithm`, this adapt the (forgotten) existing code, changing `encryptionAlgorithm` to `signatureAlgorithm` everywhere. 

2.0 being not yet released, we must profit to ensure that the introduced features are following good practices, conventions and naming.

@Spomky as you are quite aware of the good practices in term of encoding in general, it would be awesome if you could do a quick review of the terms we use in the corresponding part of our code base, especially on the `2.0` branch after #162.

For instance I thought about `encryption_engine`, is it always correct in the contexts we use it?
Otherwise, what about simply name it `engine`? That would give `encoder.engine` as option name.

Let me know about your suggestions!