### PR TITLE
Update PhpSecLib to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,15 @@
         }
     ],
     "require": {
-        "php": ">=5.4.8",
-        "symfony/framework-bundle": "~2.8|~3.0",
-        "symfony/security-bundle": "~2.8|~3.0",
-        "symfony/console": "~2.8|~3.0",
-        "namshi/jose": "~6.0"
+        "php": "^5.5|^7.0",
+        "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony/security-bundle": "^2.8|^3.0",
+        "symfony/console": "^2.8|^3.0",
+        "namshi/jose": "^7.2"
     },
     "suggest": {
-        "gesdinet/jwt-refresh-token-bundle": "Implements a refresh token system over Json Web Tokens in Symfony"
+        "gesdinet/jwt-refresh-token-bundle": "Implements a refresh token system over Json Web Tokens in Symfony",
+        "spomky-labs/lexik-jose-bridge": "JWT Token encoder with encryption support"
     },
     "autoload": {
         "psr-4": { "Lexik\\Bundle\\JWTAuthenticationBundle\\": "" }
@@ -42,8 +43,8 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.1",
-        "symfony/phpunit-bridge": "~2.7|~3.0",
-        "friendsofphp/php-cs-fixer": "~1.1"
+        "phpunit/phpunit": "^4.1|^5.0",
+        "symfony/phpunit-bridge": "^2.7|^3.0",
+        "friendsofphp/php-cs-fixer": "^1.1"
     }
 }


### PR DESCRIPTION
In order to update PhpSecLib to ^2.0 version it has been necessary to update namshi/jose (^7.2). This will drop support to PHP 5.4.