### PR TITLE
Prevent update for PhpSecLib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/security-bundle": "~2.3|~3.0",
         "symfony/console": "~2.3|~3.0",
-        "namshi/jose": "~6.0"
+        "namshi/jose": "~6.0.0"
     },
     "suggest": {
         "gesdinet/jwt-refresh-token-bundle": "Implements a refresh token system over Json Web Tokens in Symfony"


### PR DESCRIPTION
In order to prevent the update of PhpSecLib to 2.0, namshi/jose lib version must be fixed to ~6.0.0 (6.1.x requires PhpSecLib 2.0)