### PR TITLE
Introduce a FormLoginAuthenticator

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -34,6 +34,15 @@
         <!-- Default JWT Token Authenticator -->
         <service id="lexik_jwt_authentication.jwt_token_authenticator" parent="lexik_jwt_authentication.security.guard.jwt_token_authenticator" />
 
+        <!-- Abstract FormLogin Authenticator / Guard implementation -->
+        <service id="lexik_jwt_authentication.security.guard.form_login_authenticator" class="Lexik\Bundle\JWTAuthenticationBundle\Security\Guard\FormLoginAuthenticator" abstract="true">
+            <argument type="service" id="security.password_encoder" />
+            <argument type="service" id="lexik_jwt_authentication.handler.authentication_success" />
+            <argument type="service" id="lexik_jwt_authentication.handler.authentication_failure" />
+        </service>
+        <!-- Default FormLogin Authenticator -->
+        <service id="lexik_jwt_authentication.form_login_authenticator" parent="lexik_jwt_authentication.security.guard.form_login_authenticator" />
+
         <!-- JWT Authentication response interceptor -->
         <service id="lexik_jwt_authentication.handler.authentication_success" class="Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler">
             <argument type="service" id="lexik_jwt_authentication.jwt_manager"/>

--- a/Security/Guard/FormLoginAuthenticator.php
+++ b/Security/Guard/FormLoginAuthenticator.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Security\Guard;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+
+/**
+ * FormLoginAuthenticator (Guard implementation).
+ *
+ * This authenticator provides JWT tokens from given credentials.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class FormLoginAuthenticator extends AbstractGuardAuthenticator
+{
+    /**
+     * @var UserPasswordEncoderInterface
+     */
+    private $passwordEncoder;
+
+    /**
+     * @var AuthenticationSuccessHandlerInterface
+     */
+    private $authenticationSuccessHandler;
+
+    /**
+     * @var AuthenticationFailureHandlerInterface
+     */
+    private $authenticationFailureHandler;
+
+    /**
+     * @param UserPasswordEncoderInterface          $passwordEncoder
+     * @param AuthenticationSuccessHandlerInterface $authenticationSuccessHandler
+     * @param AuthenticationFailureHandlerInterface $authenticationFailureHandler
+     */
+    public function __construct(
+        UserPasswordEncoderInterface $passwordEncoder,
+        AuthenticationSuccessHandlerInterface $authenticationSuccessHandler,
+        AuthenticationFailureHandlerInterface $authenticationFailureHandler
+    ) {
+        $this->passwordEncoder              = $passwordEncoder;
+        $this->authenticationSuccessHandler = $authenticationSuccessHandler;
+        $this->authenticationFailureHandler = $authenticationFailureHandler;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCredentials(Request $request)
+    {
+        if ($this->getCheckPath() !== $request->getPathInfo()) {
+            return;
+        }
+
+        $usernameParameter = $this->getUsernameParameter();
+        $passwordParameter = $this->getPasswordParameter();
+
+        return [
+            $usernameParameter => $request->request->get($usernameParameter),
+            $passwordParameter => $request->request->get($passwordParameter),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+        return $userProvider->loadUserByUsername($credentials[$this->getUsernameParameter()]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return JWTAuthenticationFailureResponse
+     */
+    public function onAuthenticationFailure(Request $request, AuthenticationException $authException)
+    {
+        return $this->authenticationFailureHandler->onAuthenticationFailure($request, $authException);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    {
+        return $this->authenticationSuccessHandler->onAuthenticationSuccess($request, $token);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return JWTAuthenticationFailureResponse
+     */
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        return $this->onAuthenticationFailure($request, $authException ?: new AuthenticationException());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkCredentials($credentials, UserInterface $user)
+    {
+        $passwordKey = $this->getPasswordParameter();
+
+        if (null === $credentials[$passwordKey] || null === $credentials[$this->getUsernameParameter()]) {
+            throw new BadCredentialsException();
+        }
+
+        if (!$this->passwordEncoder->isPasswordValid($user, $credentials[$passwordKey])) {
+            throw new BadCredentialsException();
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsRememberMe()
+    {
+        return false;
+    }
+
+    /**
+     * Returns the username key to retrieve from the current Request.
+     *
+     * Override this method for setting a custom one.
+     *
+     * @return string
+     */
+    protected function getUsernameParameter()
+    {
+        return '_username';
+    }
+
+    /**
+     * Returns the password key to retrieve from the current Request.
+     *
+     * Override this method for setting a custom one.
+     *
+     * @return string
+     */
+    protected function getPasswordParameter()
+    {
+        return '_password';
+    }
+
+    /**
+     * Returns the login check path.
+     *
+     * Override this method for setting a custom one.
+     *
+     * @return string
+     */
+    protected function getCheckPath()
+    {
+        return '/login_check';
+    }
+}

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -28,11 +28,9 @@ security:
             pattern:  ^/login
             stateless: true
             anonymous: true
-            form_login:
-                check_path: /login_check
-                require_previous_session: false
-                success_handler: lexik_jwt_authentication.handler.authentication_success
-                failure_handler: lexik_jwt_authentication.handler.authentication_failure
+            guard:
+                authenticators:
+                    - lexik_jwt_authentication.form_login_authenticator
 
         api:
             pattern:  ^/api

--- a/Tests/Security/Guard/JWTTokenAuthenticatorTest.php
+++ b/Tests/Security/Guard/JWTTokenAuthenticatorTest.php
@@ -220,7 +220,7 @@ class JWTTokenAuthenticatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateAuthenticatedTokenThrowsExceptionIfNotPreAuthenticatedToken()
     {
-        $userStub  = new AdvancedUserStub('lexik', 'test');
+        $userStub = new AdvancedUserStub('lexik', 'test');
 
         (new JWTTokenAuthenticator(
            $this->getJWTManagerMock(),


### PR DESCRIPTION
| Q             | A    |
|---------------|------|
| Bug fix?      | no  |
| New feature?  | yes |
| BC breaks?    | not for now |
| Deprecations | yes |
| Fixed tickets | helps in #132 |
| Tests pass?   | yes  |

For now I kept the authentication success/failure listeners as is, injected into the authenticator. To me it's fine to don't move their logic in the authenticator itself, so the classic `form_login` (or whatever) can just continue to work. Plus, `GuardAuthenticatorInterface` doesn't extend the corresponding interfaces so I guess it's not a problem. Please stop me if I'm wrong.

-----

- [x] Add the authenticator
- [x] Update functional tests for using it
- [ ] Add a unit test
- [ ] Update the doc