### PR TITLE
Fix iat claim

### DIFF
--- a/Encoder/DefaultEncoder.php
+++ b/Encoder/DefaultEncoder.php
@@ -32,6 +32,8 @@ class DefaultEncoder implements JWTEncoderInterface
      */
     public function encode(array $payload)
     {
+        $payload['iat'] = time();
+
         try {
             $jws = $this->jwsProvider->create($payload);
         } catch (InvalidArgumentException $e) {


### PR DESCRIPTION
Since #162 our encoder uses `Namshi\Jose\JWS` instead of `Namshi\Jose\SimpleJWS`. I just spotted that only `SimpleJWS` set the `iat` claim.

However, I am not sure any check is done on this claim, so maybe it should be done from our encoder, as a bug fix on master (1.x). 
ping @Spomky do you know if I'm wrong?