### PR TITLE
Fix BC break by re-injecting Request instances

### DIFF
--- a/DependencyInjection/Compiler/RequestCompilerPass.php
+++ b/DependencyInjection/Compiler/RequestCompilerPass.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * RequestCompilerPass.
+ */
+final class RequestCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('lexik_jwt_authentication.jwt_manager')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('lexik_jwt_authentication.jwt_manager');
+
+        if ($container->hasDefinition('request_stack')) {
+            $definition->addMethodCall(
+                'setRequest',
+                [new Reference('request_stack', ContainerInterface::NULL_ON_INVALID_REFERENCE, false), false]
+            );
+        } else {
+            $definition->addMethodCall(
+                'setRequest',
+                [new Reference('request', ContainerInterface::NULL_ON_INVALID_REFERENCE, false), false]
+            );
+        }
+    }
+}

--- a/Event/AuthenticationFailureEvent.php
+++ b/Event/AuthenticationFailureEvent.php
@@ -39,10 +39,12 @@ class AuthenticationFailureEvent extends Event
      */
     public function __construct(Request $request = null, AuthenticationException $exception, Response $response)
     {
-        if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Passing a Request instance as first argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
+        if (func_num_args() < 4 || func_get_arg(3)) {
+            if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+                @trigger_error(sprintf('Passing a Request instance as first argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
 
-            $this->request = $request;
+                $this->request = $request;
+            }
         }
 
         $this->exception = $exception;
@@ -56,8 +58,8 @@ class AuthenticationFailureEvent extends Event
      */
     public function getRequest()
     {
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse  Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
+        if ((0 === func_num_args() || func_get_arg(0)) && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
         }
 
         return $this->request;

--- a/Event/AuthenticationSuccessEvent.php
+++ b/Event/AuthenticationSuccessEvent.php
@@ -45,10 +45,12 @@ class AuthenticationSuccessEvent extends Event
      */
     public function __construct(array $data, UserInterface $user, Request $request = null, Response $response)
     {
-        if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Passing a Request instance as third argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
+        if (func_num_args() < 5 || func_get_arg(4)) {
+            if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+                @trigger_error(sprintf('Passing a Request instance as third argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
 
-            $this->request = $request;
+                $this->request = $request;
+            }
         }
 
         $this->data = $data;
@@ -88,8 +90,8 @@ class AuthenticationSuccessEvent extends Event
      */
     public function getRequest()
     {
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse  Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
+        if ((0 === func_num_args() || func_get_arg(0)) && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
         }
 
         return $this->request;

--- a/Event/JWTCreatedEvent.php
+++ b/Event/JWTCreatedEvent.php
@@ -36,10 +36,12 @@ class JWTCreatedEvent extends Event
      */
     public function __construct(array $data, UserInterface $user, Request $request = null)
     {
-        if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Passing a Request instance as third argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
+        if (func_num_args() < 4 || func_get_arg(3)) {
+            if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+                @trigger_error(sprintf('Passing a Request instance as third argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
 
-            $this->request = $request;
+                $this->request = $request;
+            }
         }
 
         $this->data = $data;
@@ -77,8 +79,8 @@ class JWTCreatedEvent extends Event
      */
     public function getRequest()
     {
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse  Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
+        if ((0 === func_num_args() || func_get_arg(0)) && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
         }
 
         return $this->request;

--- a/Event/JWTDecodedEvent.php
+++ b/Event/JWTDecodedEvent.php
@@ -35,10 +35,12 @@ class JWTDecodedEvent extends Event
      */
     public function __construct(array $payload, Request $request = null)
     {
-        if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Passing a Request instance as second argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
+        if (func_num_args() < 3 || func_get_arg(2)) {
+            if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+                trigger_error(sprintf('Passing a Request instance as second argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
 
-            $this->request = $request;
+                $this->request = $request;
+            }
         }
 
         $this->payload = $payload;
@@ -60,8 +62,8 @@ class JWTDecodedEvent extends Event
      */
     public function getRequest()
     {
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse  Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
+        if ((0 === func_num_args() || func_get_arg(0)) && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
         }
 
         return $this->request;

--- a/Event/JWTNotFoundEvent.php
+++ b/Event/JWTNotFoundEvent.php
@@ -21,10 +21,12 @@ class JWTNotFoundEvent extends AuthenticationFailureEvent implements JWTFailureE
      */
     public function __construct(Request $request = null, AuthenticationException $exception = null, Response $response = null)
     {
-        if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Passing a Request instance as first argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
+        if (func_num_args() < 4 || func_get_arg(3)) {
+            if (null !== $request && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+                @trigger_error(sprintf('Passing a Request instance as first argument of %s() is deprecated since version 1.7 and will be removed in 2.0.%sInject the "@request_stack" service in your event listener instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
 
-            $this->request = $request;
+                $this->request = $request;
+            }
         }
 
         $this->exception = $exception;

--- a/LexikJWTAuthenticationBundle.php
+++ b/LexikJWTAuthenticationBundle.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle;
 
 use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory\JWTFactory;
+use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Compiler\RequestCompilerPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -14,6 +15,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class LexikJWTAuthenticationBundle extends Bundle
 {
+    const MAJOR_VERSION = 1;
+
     /**
      * {@inheritdoc}
      */
@@ -24,5 +27,6 @@ class LexikJWTAuthenticationBundle extends Bundle
         /** @var SecurityExtension $extension */
         $extension = $container->getExtension('security');
         $extension->addSecurityListenerFactory(new JWTFactory());
+        $container->addCompilerPass(new RequestCompilerPass());
     }
 }

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -72,12 +72,10 @@ class JWTListener implements ListenerInterface
      */
     public function handle(GetResponseEvent $event)
     {
-        // Ensure backward compatibility for Symfony < 2.8
         $request = $event->getRequest();
-        $hasRequestStack = class_exists('Symfony\Component\HttpFoundation\RequestStack');
 
         if (!$requestToken = $this->getRequestToken($request)) {
-            $jwtNotFoundEvent = new JWTNotFoundEvent($hasRequestStack ? null : $request);
+            $jwtNotFoundEvent = new JWTNotFoundEvent($request, null, null, false);
             $this->dispatcher->dispatch(Events::JWT_NOT_FOUND, $jwtNotFoundEvent);
 
             if ($response = $jwtNotFoundEvent->getResponse()) {
@@ -111,7 +109,7 @@ class JWTListener implements ListenerInterface
             $response = new JsonResponse($data, $data['code']);
             $response->headers->set('WWW-Authenticate', 'Bearer');
 
-            $jwtInvalidEvent = new JWTInvalidEvent($hasRequestStack ? null : $request, $failed, $response);
+            $jwtInvalidEvent = new JWTInvalidEvent($request, $failed, $response, false);
             $this->dispatcher->dispatch(Events::JWT_INVALID, $jwtInvalidEvent);
 
             $event->setResponse($jwtInvalidEvent->getResponse());

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -44,7 +44,7 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
         ];
 
         $response = new JsonResponse($data, self::RESPONSE_CODE);
-        $event = new AuthenticationFailureEvent(null, $exception, $response);
+        $event = new AuthenticationFailureEvent($request, $exception, $response, false);
 
         $this->dispatcher->dispatch(Events::AUTHENTICATION_FAILURE, $event);
 

--- a/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -47,7 +47,7 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
         $jwt  = $this->jwtManager->create($user);
 
         $response = new JsonResponse();
-        $event    = new AuthenticationSuccessEvent(['token' => $jwt], $user, null, $response);
+        $event    = new AuthenticationSuccessEvent(['token' => $jwt], $user, $request, $response, false);
 
         $this->dispatcher->dispatch(Events::AUTHENTICATION_SUCCESS, $event);
         $response->setData($event->getData());

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -78,7 +78,8 @@ class JWTManager implements JWTManagerInterface
             $payload,
             $user,
             // Ensure backward compatibility for Symfony < 2.8
-            class_exists('Symfony\Component\HttpFoundation\RequestStack') ? null : $this->request
+            $this->getRequest(false),
+            false
         );
         $this->dispatcher->dispatch(Events::JWT_CREATED, $jwtCreatedEvent);
 
@@ -99,7 +100,7 @@ class JWTManager implements JWTManagerInterface
             return false;
         }
 
-        $event = new JWTDecodedEvent($payload, class_exists('Symfony\Component\HttpFoundation\RequestStack') ? null : $this->request);
+        $event = new JWTDecodedEvent($payload, $this->getRequest(false), false);
         $this->dispatcher->dispatch(Events::JWT_DECODED, $event);
 
         if (!$event->isValid()) {
@@ -145,7 +146,7 @@ class JWTManager implements JWTManagerInterface
      */
     public function setRequest($requestStack)
     {
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+        if ((1 === func_num_args() || func_get_arg(1)) && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
             @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.', __METHOD__), E_USER_DEPRECATED);
         }
 
@@ -163,8 +164,8 @@ class JWTManager implements JWTManagerInterface
      */
     public function getRequest()
     {
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.', __METHOD__), E_USER_DEPRECATED);
+        if ((0 === func_num_args() || func_get_arg(0)) && class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            @trigger_error(sprintf('Method %s() is deprecated since version 1.7 and will be removed in 2.0.%sUse Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest() instead.', __METHOD__, PHP_EOL), E_USER_DEPRECATED);
         }
 
         return $this->request;


### PR DESCRIPTION
Muting deprecation warnings for internal calls.
Closes #244 