### PR TITLE
Add a simple built-in encoder based on lcobucci/jwt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,8 @@ before_install:
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 
 install: composer update --prefer-dist --no-interaction
+
+script:
+    - vendor/bin/phpunit --testsuite unit
+    - SYMFONY__JWT__ENCODER=default vendor/bin/phpunit --testsuite functional
+    - SYMFONY__JWT__ENCODER=lcobucci vendor/bin/phpunit --testsuite functional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ For a diff between two versions https://github.com/lexik/LexikJWTAuthenticationB
 
 ## [2.0](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/2.0)
 
+* feature [\#246](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/247) Add a simple built-in encoder based on lcobucci/jw ([chalasr](https://github.com/chalasr))
+
 * feature [\#240](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/240) Add iat check ([chalasr](https://github.com/chalasr))
 
 * feature [\#230](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/230) Introduce JWTExpiredEvent ([chalasr](https://github.com/chalasr))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ For a diff between two versions https://github.com/lexik/LexikJWTAuthenticationB
 
 ## [2.0](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/2.0)
 
-* feature [\#246](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/247) Add a simple built-in encoder based on lcobucci/jw ([chalasr](https://github.com/chalasr))
+* feature [\#246](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/247) Add a simple built-in encoder based on lcobucci/jwt ([chalasr](https://github.com/chalasr))
 
 * feature [\#240](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/240) Add iat check ([chalasr](https://github.com/chalasr))
 

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -36,7 +36,7 @@ class LexikJWTAuthenticationExtension extends Extension
         $container->setAlias('lexik_jwt_authentication.encoder', $encoderConfig['service']);
         $container->setAlias(
             'lexik_jwt_authentication.key_loader',
-            'lexik_jwt_authentication.key_loader.'.$encoderConfig['encryption_engine']
+            'lexik_jwt_authentication.key_loader.'.('openssl' === $encoderConfig['encryption_engine'] ? $encoderConfig['encryption_engine'] : 'raw')
         );
         $container->setParameter('lexik_jwt_authentication.encoder.signature_algorithm', $encoderConfig['signature_algorithm']);
         $container->setParameter('lexik_jwt_authentication.encoder.encryption_engine', $encoderConfig['encryption_engine']);

--- a/Encoder/DefaultEncoder.php
+++ b/Encoder/DefaultEncoder.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Encoder;
 use InvalidArgumentException;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTEncodeFailureException;
-use Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProviderInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\JWSProviderInterface;
 
 /**
  * Default Json Web Token encoder/decoder.
@@ -32,8 +32,6 @@ class DefaultEncoder implements JWTEncoderInterface
      */
     public function encode(array $payload)
     {
-        $payload['iat'] = time();
-
         try {
             $jws = $this->jwsProvider->create($payload);
         } catch (InvalidArgumentException $e) {

--- a/Encoder/LcobucciJWTEncoder.php
+++ b/Encoder/LcobucciJWTEncoder.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Encoder;
+
+/**
+ * Json Web Token encoder/decoder based on the lcobucci/jwt library.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class LcobucciJWTEncoder extends DefaultEncoder
+{
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,9 +5,15 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <!--  Default JWT Encoder / Decoder -->
-        <service id="lexik_jwt_authentication.encoder.default" class="Lexik\Bundle\JWTAuthenticationBundle\Encoder\DefaultEncoder">
-            <argument type="service" id="lexik_jwt_authentication.jws_provider"/>
+        <!--  Default JWT Encoder / Decoder (Namshi/JOSE based) -->
+        <service id="lexik_jwt_authentication.encoder.abstract" class="Lexik\Bundle\JWTAuthenticationBundle\Encoder\DefaultEncoder" abstract="true">
+        </service>
+        <service id="lexik_jwt_authentication.encoder.default" parent="lexik_jwt_authentication.encoder.abstract">
+            <argument type="service" id="lexik_jwt_authentication.jws_provider.default"/>
+        </service>
+        <!--  Lcobucci/JWT Encoder / Decoder -->
+        <service id="lexik_jwt_authentication.encoder.lcobucci" parent="lexik_jwt_authentication.encoder.abstract">
+            <argument type="service" id="lexik_jwt_authentication.jws_provider.lcobucci" />
         </service>
         <!-- JWT Manager / Default implementation -->
         <service id="lexik_jwt_authentication.jwt_manager" class="Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager">
@@ -18,9 +24,15 @@
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>
             </call>
         </service>
-        <!--  JWS Provider -->
-        <service id="lexik_jwt_authentication.jws_provider" class="Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider" public="false">
+        <!-- Default JWS Provider (Namshi JOSE based) -->
+        <service id="lexik_jwt_authentication.jws_provider.default" class="Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\DefaultJWSProvider" public="false">
             <argument type="service" id="lexik_jwt_authentication.key_loader"/>
+            <argument>%lexik_jwt_authentication.encoder.encryption_engine%</argument>
+            <argument>%lexik_jwt_authentication.encoder.signature_algorithm%</argument>
+        </service>
+        <!-- Lcobucci/JWT JWS Provider -->
+        <service id="lexik_jwt_authentication.jws_provider.lcobucci" class="Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\LcobucciJWSProvider" public="false">
+            <argument type="service" id="lexik_jwt_authentication.key_loader.raw"/>
             <argument>%lexik_jwt_authentication.encoder.encryption_engine%</argument>
             <argument>%lexik_jwt_authentication.encoder.signature_algorithm%</argument>
         </service>
@@ -52,7 +64,7 @@
             <argument>%lexik_jwt_authentication.pass_phrase%</argument>
         </service>
         <service id="lexik_jwt_authentication.key_loader.openssl" class="Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\OpenSSLKeyLoader" parent="lexik_jwt_authentication.key_loader.abstract"/>
-        <service id="lexik_jwt_authentication.key_loader.phpseclib" class="Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\SecLibKeyLoader" parent="lexik_jwt_authentication.key_loader.abstract"/>
+        <service id="lexik_jwt_authentication.key_loader.raw" class="Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\RawKeyLoader" parent="lexik_jwt_authentication.key_loader.abstract"/>
 
         <!-- JWT Security Authentication Provider (Deprecated in 2.0) -->
         <service id="lexik_jwt_authentication.security.authentication.provider" class="Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Provider\JWTProvider" public="false">

--- a/Resources/doc/1-configuration-reference.md
+++ b/Resources/doc/1-configuration-reference.md
@@ -61,7 +61,11 @@ lexik_jwt_authentication:
 
 ##### service
 
-Default based on the [Namshi/JOSE](https://github.com/namshi/jose) library.  
+Default to `lexik_jwt_authentication.encoder.default` which is based on the [Namshi/JOSE](https://github.com/namshi/jose) library.  
+You can also use `lexik_jwt_authentication.encoder.lcobucci` which is based on the [Lcobucci/JWT](https://github.com/lcobucci/jwt) library and concern the same usage level as the default one, providing an easy way to validate claims.
+
+For an advanced token encoding with higher encryption support, please see the [`Spomky-Labs/lexik-jose-bridge`](https://github.com/Spomky-Labs/lexik-jose-bridge) which is based on the great [`Spomky-Labs/JOSE`](https://github.com/Spomky-Labs/JOSE) library.
+
 To create your own encoder service, see the [JWT encoder service customization chapter](5-encoder-service.md).
 
 ##### encryption_engine

--- a/Resources/doc/5-encoder-service.md
+++ b/Resources/doc/5-encoder-service.md
@@ -1,8 +1,11 @@
 JWT encoder service customization
 =================================
+, 
+This bundle comes with two built-in token encoders, one based on the [`namshi/jose`](https://github.com/namshi/jose) library (default) and the later based on the []`lcobucci/jwt`](https://github.com/lcobucci/jwt) library.
+If both don't suit your needs, you can replace it with your own encoder service. Here's an example implementing a [`nixilla/php-jwt`](https://github.com/nixilla/php-jwt) library based encoder.
 
-This bundle comes with a [`namshi/jose`](https://github.com/namshi/jose) library based token encoder as it uses SSH keys to encrypt and decrypt data.
-If this doesn't suit your needs, you can replace it with your own encoder service. Here's an example implementing a [`nixilla/php-jwt`](https://github.com/nixilla/php-jwt) library based encoder.
+Creating your own encoder
+--------------------------
 
 ### Create the encoder class
 

--- a/Services/JWSProvider/DefaultJWSProvider.php
+++ b/Services/JWSProvider/DefaultJWSProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lexik\Bundle\JWTAuthenticationBundle\Services;
+namespace Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\KeyLoaderInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Signature\CreatedJWS;
@@ -15,7 +15,7 @@ use Namshi\JOSE\JWS;
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-class JWSProvider implements JWSProviderInterface
+class DefaultJWSProvider implements JWSProviderInterface
 {
     /**
      * @var KeyLoaderInterface
@@ -61,7 +61,7 @@ class JWSProvider implements JWSProviderInterface
     {
         $jws = new JWS(['alg' => $this->signatureAlgorithm], $this->encryptionEngine);
 
-        $jws->setPayload($payload);
+        $jws->setPayload($payload + ['iat' => time()]);
         $jws->sign(
             $this->keyLoader->loadKey('private'),
             $this->keyLoader->getPassphrase()

--- a/Services/JWSProvider/JWSProviderInterface.php
+++ b/Services/JWSProvider/JWSProviderInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lexik\Bundle\JWTAuthenticationBundle\Services;
+namespace Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider;
 
 /**
  * Interface for classes that are able to create and load JSON web signatures (JWS).

--- a/Services/JWSProvider/LcobucciJWSProvider.php
+++ b/Services/JWSProvider/LcobucciJWSProvider.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider;
+
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Signer\Keychain;
+use Lcobucci\JWT\ValidationData;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\KeyLoaderInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Signature\CreatedJWS;
+use Lexik\Bundle\JWTAuthenticationBundle\Signature\LoadedJWS;
+
+class LcobucciJWSProvider implements JWSProviderInterface
+{
+    /**
+     * @var KeyLoaderInterface
+     */
+    private $keyLoader;
+
+    /**
+     * @var string
+     */
+    private $signatureAlgorithm;
+
+    /**
+     * @param KeyLoaderInterface $keyLoader
+     * @param string             $encryptionEngine
+     * @param string             $signatureAlgorithm
+     *
+     * @throws \InvalidArgumentException If the given algorithm is not supported
+     */
+    public function __construct(KeyLoaderInterface $keyLoader, $encryptionEngine, $signatureAlgorithm)
+    {
+        $this->keyLoader = $keyLoader;
+        $this->signer    = $this->getSignerForAlgorithm($signatureAlgorithm);
+
+        if ('openssl' !== $encryptionEngine) {
+            throw new \InvalidArgumentException(sprintf('The %s provider supports only "openssl" as encryption engine.', __CLASS__));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $payload)
+    {
+        $jws = (new Builder())
+            ->setIssuedAt(time())
+            ->setExpiration($payload['exp']);
+
+        foreach ($this->getCustomClaims($payload) as $name => $value) {
+            $jws->set($name, $value);
+        }
+
+        try {
+            $jws->sign(
+                $this->signer,
+                (new Keychain())->getPrivateKey($this->keyLoader->loadKey('private'), $this->keyLoader->getPassphrase())
+            );
+            $signed = true;
+        } catch (\InvalidArgumentException $e) {
+            $signed = false;
+        }
+
+        return new CreatedJWS((string) $jws->getToken(), $signed);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load($token)
+    {
+        $jws = (new Parser())->parse((string) $token);
+
+        $payload = [];
+        foreach ($jws->getClaims() as $claim) {
+            $payload[$claim->getName()] = $claim->getValue();
+        }
+
+        return new LoadedJWS(
+            $payload,
+            $jws->verify($this->signer, (new Keychain())->getPublicKey($this->keyLoader->loadKey('public'), $this->signatureAlgorithm)) &&
+            $jws->validate(new ValidationData())
+        );
+    }
+
+    private function getSignerForAlgorithm($signatureAlgorithm)
+    {
+        if (0 === $pos = strpos($signatureAlgorithm, 'HS')) {
+            $signerType = 'Hmac';
+        } elseif (0 === $pos = strpos($signatureAlgorithm, 'RS')) {
+            $signerType = 'Rsa';
+        } elseif (0 === $pos = strpos($signatureAlgorithm, 'EC')) {
+            $signerType = 'Ecdsa';
+        }
+
+        if (!isset($signerType) || !isset($pos)) {
+            throw new \InvalidArgumentException(
+                sprintf('The algorithm "%s" is not supported by %s', $signatureAlgorithm, __CLASS__)
+            );
+        }
+
+        $bits   = substr($signatureAlgorithm, 2, strlen($signatureAlgorithm));
+        $signer = sprintf('Lcobucci\\JWT\\Signer\\%s\\Sha%s', $signerType, $bits);
+
+        return new $signer();
+    }
+
+    private function getCustomClaims(array $claims = [])
+    {
+        $standardClaimNames = ['jti', 'iss', 'aud', 'sub', 'iat', 'nbf', 'exp'];
+        $customClaimNames   = array_filter(array_keys($claims), function ($name) use ($standardClaimNames) {
+            return !in_array($name, $standardClaimNames);
+        });
+
+        $customClaims = [];
+        foreach ($customClaimNames as $name) {
+            $customClaims[$name] = $claims[$name];
+        }
+
+        return $customClaims;
+    }
+}

--- a/Services/KeyLoader/RawKeyLoader.php
+++ b/Services/KeyLoader/RawKeyLoader.php
@@ -12,6 +12,8 @@ class RawKeyLoader extends AbstractKeyLoader
     /**
      * {@inheritdoc}
      *
+     * @return string
+     *
      * @throws \RuntimeException If the key cannot be read
      */
     public function loadKey($type)

--- a/Services/KeyLoader/RawKeyLoader.php
+++ b/Services/KeyLoader/RawKeyLoader.php
@@ -3,11 +3,11 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader;
 
 /**
- * Load crypto keys for the phpseclib encryption engine.
+ * Reads crypto keys, mainly useful for using the phpseclib encryption engine.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-class SecLibKeyLoader extends AbstractKeyLoader
+class RawKeyLoader extends AbstractKeyLoader
 {
     /**
      * {@inheritdoc}

--- a/Tests/Encoder/DefaultEncoderTest.php
+++ b/Tests/Encoder/DefaultEncoderTest.php
@@ -3,7 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Encoder;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Encoder\DefaultEncoder;
-use Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\DefaultJWSProvider;
 use Lexik\Bundle\JWTAuthenticationBundle\Signature\CreatedJWS;
 use Lexik\Bundle\JWTAuthenticationBundle\Signature\LoadedJWS;
 
@@ -130,7 +130,7 @@ class DefaultEncoderTest extends \PHPUnit_Framework_TestCase
      */
     private function getJWSProviderMock()
     {
-        return $this->getMockBuilder(JWSProvider::class)
+        return $this->getMockBuilder(DefaultJWSProvider::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/Functional/DependencyInjection/LexikJWTAuthenticationExtensionTest.php
+++ b/Tests/Functional/DependencyInjection/LexikJWTAuthenticationExtensionTest.php
@@ -4,6 +4,7 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\DependencyInject
 
 use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\LexikJWTAuthenticationExtension;
 use Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\DefaultJWSProvider;
 use Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\TestCase;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\Config\FileLocator;
@@ -40,7 +41,7 @@ class LexikJWTAuthenticationExtensionTest extends TestCase
         $signatureAlgorithm = $container->getParameter($encoderNamespace.'.signature_algorithm');
 
         $jwsProviderMock = $this
-            ->getMockBuilder('Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider')
+            ->getMockBuilder(DefaultJWSProvider::class)
             ->setConstructorArgs([
                 $container->get('lexik_jwt_authentication.key_loader'),
                 $encryptionEngine,

--- a/Tests/Functional/TestCase.php
+++ b/Tests/Functional/TestCase.php
@@ -20,7 +20,7 @@ abstract class TestCase extends WebTestCase
     {
         require_once __DIR__.'/app/AppKernel.php';
 
-        return new AppKernel('test', true);
+        return new AppKernel(getenv('SYMFONY__JWT__ENCODER') ?: 'default', true);
     }
 
     protected static function createAuthenticatedClient($token = null)

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -49,6 +49,6 @@ class AppKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(__DIR__.'/config/config.yml');
+        $loader->load(__DIR__.sprintf('/config/config_%s.yml', $this->getEnvironment()));
     }
 }

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -6,11 +6,6 @@ framework:
     session:
         storage_id: session.storage.mock_file
 
-lexik_jwt_authentication:
-    private_key_path:   '%kernel.root_dir%/../var/jwt/private.pem'
-    public_key_path:    '%kernel.root_dir%/../var/jwt/public.pem'
-    pass_phrase:        testing
-
 security:
     encoders:
         Symfony\Component\Security\Core\User\User: plaintext

--- a/Tests/Functional/app/config/config_default.yml
+++ b/Tests/Functional/app/config/config_default.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: config.yml }
+
+lexik_jwt_authentication:
+    private_key_path:   '%kernel.root_dir%/../var/jwt/private.pem'
+    public_key_path:    '%kernel.root_dir%/../var/jwt/public.pem'
+    pass_phrase:        testing
+    encoder:
+        service: lexik_jwt_authentication.encoder.default

--- a/Tests/Functional/app/config/config_lcobucci.yml
+++ b/Tests/Functional/app/config/config_lcobucci.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: config.yml }
+
+lexik_jwt_authentication:
+    private_key_path:   '%kernel.root_dir%/../var/jwt/private.pem'
+    public_key_path:    '%kernel.root_dir%/../var/jwt/public.pem'
+    pass_phrase:        testing
+    encoder:
+        service: lexik_jwt_authentication.encoder.lcobucci

--- a/Tests/Services/JWSProvider/DefaultJWSProviderTest.php
+++ b/Tests/Services/JWSProvider/DefaultJWSProviderTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Services\JWSProvider;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\DefaultJWSProvider;
+
+/**
+ * Tests the DefaultJWSProvider.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class DefaultJWSProviderTest extends AbstractJWSProviderTest
+{
+    public function __construct()
+    {
+        self::$providerClass = DefaultJWSProvider::class;
+    }
+}

--- a/Tests/Services/JWSProvider/LcobucciJWSProviderTest.php
+++ b/Tests/Services/JWSProvider/LcobucciJWSProviderTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Services\JWSProvider;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\LcobucciJWSProvider;
+
+/**
+ * Tests the LcobucciJWSProvider.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class LcobucciJWSProviderTest extends AbstractJWSProviderTest
+{
+    public function __construct()
+    {
+        self::$providerClass = LcobucciJWSProvider::class;
+    }
+}

--- a/Tests/Services/KeyLoader/RawKeyLoaderTest.php
+++ b/Tests/Services/KeyLoader/RawKeyLoaderTest.php
@@ -2,21 +2,21 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Services\KeyLoader;
 
-use Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\SecLibKeyLoader;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\RawKeyLoader;
 
 /**
- * SecLibKeyLoaderTest.
+ * RawKeyLoaderTest.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-class SecLibKeyLoaderTest extends AbstractTestKeyLoader
+class RawKeyLoaderTest extends AbstractTestKeyLoader
 {
     /**
      * {@inheritdoc}
      */
     public function setUp()
     {
-        $this->keyLoader = new SecLibKeyLoader('private.pem', 'public.pem', 'foobar');
+        $this->keyLoader = new RawKeyLoader('private.pem', 'public.pem', 'foobar');
 
         parent::setup();
     }

--- a/composer.json
+++ b/composer.json
@@ -47,11 +47,13 @@
         "phpunit/phpunit": "^4.1|^5.0",
         "symfony/phpunit-bridge": "^2.8|^3.0",
         "symfony/browser-kit": "^2.8|^3.0",
-        "friendsofphp/php-cs-fixer": "^1.1"
+        "friendsofphp/php-cs-fixer": "^1.1",
+        "lcobucci/jwt": "~3.2"
     },
     "suggest": {
         "gesdinet/jwt-refresh-token-bundle": "Implements a refresh token system over Json Web Tokens in Symfony",
-        "spomky-labs/lexik-jose-bridge": "JWT Token encoder with encryption support"
+        "spomky-labs/lexik-jose-bridge": "Provides a JWT Token encoder with encryption support",
+        "lcobucci/jwt": "For using the LcobucciJWTEncoder"
     },
     "autoload": {
         "psr-4": { "Lexik\\Bundle\\JWTAuthenticationBundle\\": "" },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,9 +11,14 @@
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
         >
+
     <testsuites>
-        <testsuite name="LexikJWTAuthenticationBundle Test Suite">
+        <testsuite name="unit">
             <directory>./Tests/</directory>
+            <exclude>./Tests/Functional/</exclude>
+        </testsuite>
+        <testsuite name="functional">
+            <directory>./Tests/Functional/</directory>
         </testsuite>
     </testsuites>
 
@@ -28,7 +33,4 @@
         </whitelist>
     </filter>
 
-    <php>
-        <server name="ROOT_DIR" value="../../../../.." />
-    </php>
 </phpunit>


### PR DESCRIPTION
| Q             | A    |
|---------------|------|
| Bug fix?      | no  |
| New feature?  | yes |
| BC breaks?    | no |
| Deprecations | no |
| Fixed tickets | #132 |
| Tests pass?   | yes  |

This adds an alternative to the default encoder for the same kind of usage level, with a different Api, allowing to validate claims (contrarily to the default one).