### PR TITLE
Avoid setting exp claim from JWTManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ For a diff between two versions https://github.com/lexik/LexikJWTAuthenticationB
 
 ## [2.0](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/2.0)
 
-* feature [\#246](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/247) Add a simple built-in encoder based on lcobucci/jwt ([chalasr](https://github.com/chalasr))
+* feature [\#249](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/249) Avoid setting exp claim from JWTManager ([chalasr](https://github.com/chalasr))
+
+* feature [\#246](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/246) Add a simple built-in encoder based on lcobucci/jwt ([chalasr](https://github.com/chalasr))
 
 * feature [\#240](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/240) Add iat check ([chalasr](https://github.com/chalasr))
 
@@ -15,7 +17,7 @@ For a diff between two versions https://github.com/lexik/LexikJWTAuthenticationB
 
 * feature [\#218](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/218) Add more flexibility in token extractors configuration ([chalasr](https://github.com/chalasr))
 
-* feature [\#217](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/217) Refactor TokenExtractors loading for easy overriding ([chalasr](https://github.com/chalasr))
+* feature [\#217](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/217) Refactor TokenExtractors loadi ng for easy overriding ([chalasr](https://github.com/chalasr))
 
 * feature [\#202](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/202) Exceptions simplified ([Spomky](https://github.com/Spomky))
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -42,6 +42,12 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('token_ttl')
                     ->defaultValue(3600)
+                    ->validate()
+                        ->ifTrue(function ($ttl) {
+                            return !is_numeric($ttl);
+                        })
+                        ->thenInvalid('The token_ttl must be a numeric value.')
+                    ->end()
                 ->end()
                 ->arrayNode('encoder')
                     ->addDefaultsIfNotSet()

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -19,7 +19,6 @@
         <service id="lexik_jwt_authentication.jwt_manager" class="Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager">
             <argument type="service" id="lexik_jwt_authentication.encoder"/>
             <argument type="service" id="event_dispatcher"/>
-            <argument>%lexik_jwt_authentication.token_ttl%</argument>
             <call method="setUserIdentityField">
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>
             </call>
@@ -29,12 +28,14 @@
             <argument type="service" id="lexik_jwt_authentication.key_loader"/>
             <argument>%lexik_jwt_authentication.encoder.crypto_engine%</argument>
             <argument>%lexik_jwt_authentication.encoder.signature_algorithm%</argument>
+            <argument>%lexik_jwt_authentication.token_ttl%</argument>
         </service>
         <!-- Lcobucci/JWT JWS Provider -->
         <service id="lexik_jwt_authentication.jws_provider.lcobucci" class="Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\LcobucciJWSProvider" public="false">
             <argument type="service" id="lexik_jwt_authentication.key_loader.raw"/>
             <argument>%lexik_jwt_authentication.encoder.crypto_engine%</argument>
             <argument>%lexik_jwt_authentication.encoder.signature_algorithm%</argument>
+            <argument>%lexik_jwt_authentication.token_ttl%</argument>
         </service>
 
         <!-- Abstract JWT Token Authenticator / Guard implementation -->

--- a/Services/JWSProvider/DefaultJWSProvider.php
+++ b/Services/JWSProvider/DefaultJWSProvider.php
@@ -33,13 +33,19 @@ class DefaultJWSProvider implements JWSProviderInterface
     private $signatureAlgorithm;
 
     /**
+     * @var int
+     */
+    private $ttl;
+
+    /**
      * @param KeyLoaderInterface $keyLoader
      * @param string             $cryptoEngine
      * @param string             $signatureAlgorithm
+     * @param int                $ttl
      *
      * @throws \InvalidArgumentException If the given algorithm is not supported
      */
-    public function __construct(KeyLoaderInterface $keyLoader, $cryptoEngine, $signatureAlgorithm)
+    public function __construct(KeyLoaderInterface $keyLoader, $cryptoEngine, $signatureAlgorithm, $ttl)
     {
         $cryptoEngine = $cryptoEngine == 'openssl' ? 'OpenSSL' : 'SecLib';
 
@@ -52,6 +58,7 @@ class DefaultJWSProvider implements JWSProviderInterface
         $this->keyLoader          = $keyLoader;
         $this->cryptoEngine       = $cryptoEngine;
         $this->signatureAlgorithm = $signatureAlgorithm;
+        $this->ttl                = $ttl;
     }
 
     /**
@@ -61,7 +68,7 @@ class DefaultJWSProvider implements JWSProviderInterface
     {
         $jws = new JWS(['alg' => $this->signatureAlgorithm], $this->cryptoEngine);
 
-        $jws->setPayload($payload + ['iat' => time()]);
+        $jws->setPayload($payload + ['exp' => (time() + $this->ttl), 'iat' => time()]);
         $jws->sign(
             $this->keyLoader->loadKey('private'),
             $this->keyLoader->getPassphrase()

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -31,11 +31,6 @@ class JWTManager implements JWTManagerInterface, JWTTokenManagerInterface
     protected $dispatcher;
 
     /**
-     * @var integer
-     */
-    protected $ttl;
-
-    /**
      * @var string
      */
     protected $userIdentityField;
@@ -43,13 +38,11 @@ class JWTManager implements JWTManagerInterface, JWTTokenManagerInterface
     /**
      * @param JWTEncoderInterface      $encoder
      * @param EventDispatcherInterface $dispatcher
-     * @param int                      $ttl
      */
-    public function __construct(JWTEncoderInterface $encoder, EventDispatcherInterface $dispatcher, $ttl)
+    public function __construct(JWTEncoderInterface $encoder, EventDispatcherInterface $dispatcher)
     {
         $this->jwtEncoder        = $encoder;
         $this->dispatcher        = $dispatcher;
-        $this->ttl               = $ttl;
         $this->userIdentityField = 'username';
     }
 
@@ -59,11 +52,6 @@ class JWTManager implements JWTManagerInterface, JWTTokenManagerInterface
     public function create(UserInterface $user)
     {
         $payload = [];
-
-        if (is_numeric($this->ttl)) {
-            $payload['exp'] = time() + $this->ttl;
-        }
-
         $this->addUserIdentityToPayload($user, $payload);
 
         $jwtCreatedEvent = new JWTCreatedEvent($payload, $user);

--- a/Tests/Functional/DependencyInjection/LexikJWTAuthenticationExtensionTest.php
+++ b/Tests/Functional/DependencyInjection/LexikJWTAuthenticationExtensionTest.php
@@ -46,6 +46,7 @@ class LexikJWTAuthenticationExtensionTest extends TestCase
                 $container->get('lexik_jwt_authentication.key_loader'),
                 $cryptoEngine,
                 $signatureAlgorithm,
+                3600,
             ])
             ->getMock();
 

--- a/Tests/Services/JWSProvider/AbstractJWSProviderTest.php
+++ b/Tests/Services/JWSProvider/AbstractJWSProviderTest.php
@@ -75,8 +75,8 @@ vwIDAQAB
             ->method('getPassphrase')
             ->willReturn('foobar');
 
-        $payload     = ['username' => 'chalasr', 'exp' => time() + 3600];
-        $jwsProvider = new self::$providerClass($keyLoaderMock, 'openssl', 'RS384');
+        $payload     = ['username' => 'chalasr'];
+        $jwsProvider = new self::$providerClass($keyLoaderMock, 'openssl', 'RS384', 3600);
 
         $this->assertInstanceOf(CreatedJWS::class, $created = $jwsProvider->create($payload));
 
@@ -97,8 +97,14 @@ vwIDAQAB
             ->with('public')
             ->willReturn(self::$publicKey);
 
-        $jwsProvider = new self::$providerClass($keyLoaderMock, 'openssl', 'RS384');
-        $this->assertInstanceOf(LoadedJWS::class, $jwsProvider->load($jwt));
+        $jwsProvider = new self::$providerClass($keyLoaderMock, 'openssl', 'RS384', 3600);
+        $loadedJWS   = $jwsProvider->load($jwt);
+        $this->assertInstanceOf(LoadedJWS::class, $loadedJWS);
+
+        $payload = $loadedJWS->getPayload();
+        $this->assertTrue(isset($payload['exp']));
+        $this->assertTrue(isset($payload['iat']));
+        $this->assertTrue(isset($payload['username']));
     }
 
     /**
@@ -107,7 +113,7 @@ vwIDAQAB
      */
     public function testInvalidsignatureAlgorithm()
     {
-        new self::$providerClass($this->getKeyLoaderMock(), 'openssl', 'wrongAlgorithm');
+        new self::$providerClass($this->getKeyLoaderMock(), 'openssl', 'wrongAlgorithm', 3600);
     }
 
     /**

--- a/Tests/Services/JWTManagerTest.php
+++ b/Tests/Services/JWTManagerTest.php
@@ -43,7 +43,7 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
             ->method('encode')
             ->willReturn('secrettoken');
 
-        $manager = new JWTManager($encoder, $dispatcher, 3600);
+        $manager = new JWTManager($encoder, $dispatcher);
         $this->assertEquals('secrettoken', $manager->create(new User('user', 'password')));
     }
 
@@ -67,7 +67,7 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
             ->method('decode')
             ->willReturn(['foo' => 'bar']);
 
-        $manager = new JWTManager($encoder, $dispatcher, 3600);
+        $manager = new JWTManager($encoder, $dispatcher);
         $this->assertEquals(['foo' => 'bar'], $manager->decode($this->getJWTUserTokenMock()));
     }
 
@@ -99,7 +99,7 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
             ->method('encode')
             ->willReturn('secrettoken');
 
-        $manager = new JWTManager($encoder, $dispatcher, 3600);
+        $manager = new JWTManager($encoder, $dispatcher);
         $manager->setUserIdentityField('email');
         $this->assertEquals('secrettoken', $manager->create(new CustomUser('user', 'password', 'victuxbb@gmail.com')));
     }

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -162,3 +162,6 @@ Security
   implementing two new methods: `setUserIdentityField` and `getUserIdentityField`.
   These methods were already implemented by the JWTManager class in 1.x but not guaranteed
   by the old interface.
+
+* The `JWTManager` is no more responsible of setting the token 
+  `exp` claim, meaning that its constructor takes one less argument (the last one). This logic has been moved to the `Encoder` that is responsible of creating signed tokens and verifying/validating existing ones.


### PR DESCRIPTION
| Q             | A    |
|---------------|------|
| Bug fix?      | no  |
| New feature?  | yes |
| BC breaks?    | yes |
| Deprecations | no |
| Fixed tickets | n/a |
| Tests pass?   | yes  |

The encoder should be responsible of setting the `exp` claim and all other standard ones. @Spomky this might have an impact on the `lexik_jose_bridge`, excepted if you set this claim from the encoder anyway.

- [x] Inject the configured `ttl` in `*JWSProvider` rather than `JWTManager`
- [x] Update tests
- [ ] Add an UPGRADE+CHANGELOG note