### PR TITLE
Adding `getProviderKey()` to JWTUserToken

### DIFF
--- a/Security/Authentication/Token/JWTUserToken.php
+++ b/Security/Authentication/Token/JWTUserToken.php
@@ -55,4 +55,14 @@ class JWTUserToken extends AbstractToken implements GuardTokenInterface
     {
         return $this->rawToken;
     }
+
+    /**
+     * Returns the provider key.
+     *
+     * @return string The provider key
+     */
+    public function getProviderKey()
+    {
+        return $this->providerKey;
+    }
 }


### PR DESCRIPTION
In some situations it is useful to get the security provider key from the token. In fact, JWTUserToken is constructed with `$providerKey` but it is never used and there is no getter for it, hence my addition.
It is also consistent with Symfony's `UsernamePasswordToken`, `RememberMeToken` or `PreAuthenticatedToken` which all have such getter.