### PR TITLE
Ease creating tokens programatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ LexikJWTAuthenticationBundle
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/67573b6f-e182-4394-b26a-649c323784f6/mini.png)](https://insight.sensiolabs.com/projects/67573b6f-e182-4394-b26a-649c323784f6)
 [![Latest Stable Version](https://poser.pugx.org/lexik/jwt-authentication-bundle/v/stable.svg)](https://packagist.org/packages/lexik/jwt-authentication-bundle)
 
-This bundle provides JWT (Json Web Token) authentication for your Symfony REST API default using the [`namshi/jose`](https://github.com/namshi/jose) library.
+This bundle provides JWT (Json Web Token) authentication for your Symfony API.
 
-It is compatible and tested with PHP 5.5, 5.6, 7.0, 7.1, HHVM and Symfony 2.8, 3.0 and 3.1.
+It is compatible and tested with PHP 5.5, 5.6, 7.0, 7.1, HHVM on Symfony 2.8, 3.0, 3.1 and 3.2.
 
 Documentation
 -------------
@@ -29,6 +29,8 @@ The bulk of the documentation is stored in the [`Resources/doc`](Resources/doc/i
   * [Working with CORS requests](Resources/doc/4-cors-requests.md)
   * [JWT encoder service customization](Resources/doc/5-encoder-service.md)
   * [Extending JWTTokenAuthenticator](Resources/doc/6-extending-jwt-authenticator.md)
+  * [Extending JWTTokenAuthenticator](Resources/doc/6-extending-jwt-authenticator.md)
+  * [Creating JWT tokens programmatically](Resources/doc/7-manual-token-creation.md)
 
 Support
 -------

--- a/Resources/doc/4-cors-requests.md
+++ b/Resources/doc/4-cors-requests.md
@@ -1,7 +1,7 @@
 Working with CORS requests
 ==========================
 
-There are several ways to add CORS requests handling capabilities to a Symfony2 application,
+There are several ways to add CORS requests handling capabilities to a Symfony application,
 the fastest and most flexible solution being the [`NelmioCorsBundle`](https://github.com/nelmio/NelmioCorsBundle).
 
 This bundle allows you to enable and configure CORS rules very precisely without having to modify your server configuration.

--- a/Resources/doc/7-manual-token-creation.md
+++ b/Resources/doc/7-manual-token-creation.md
@@ -1,0 +1,46 @@
+Creating JWT tokens programmatically
+===================================
+
+It might be useful in many cases to manually create a JWT token for a given user, after confirming user registration by mail for instance.
+To achieve this, use the `lexik_jwt_authentication.jwt_manager` service directly:
+
+```php
+namespace AppBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class ApiController extends Controller
+{
+    public function fooAction(UserInterface $user)
+    {
+        // ...
+
+        $jwtManager = $this->container->get('lexik_jwt_authentication.jwt_manager');
+
+        return new JsonResponse(['token' => $jwtManager->create($user)]);
+    }
+}
+```
+
+This dispatches the `Events::JWT_CREATED`, `Events::JWT_ENCODED` events and returns a JWT token, but the `Events::AUTHENTCIATION_SUCCESS` event is not dispatched, you need to create and format the response by yourself.
+
+For manually authenticating an user and returning the same response as your login form:
+
+```php
+public function fooAction(UserInterface $user)
+{    
+    $authenticationSuccessHandler = $this->container->get('lexik_jwt_authentication.handler.authentication_success');
+    
+    return $authenticationSuccessHandler->handleAuthenticationSuccess($user);
+}
+```
+
+You can also pass an existing JWT to the `handleAuthenticationSuccess` method:
+
+```php
+$jwt = $this->container->get('lexik_jwt_authentication.jwt_manager')->create($user);
+
+return $authenticationSuccessHandler->handleAuthenticationSuccess($user, $jwt);
+```

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -184,3 +184,4 @@ The following documents are available:
 - [Working with CORS requests](4-cors-requests.md)
 - [JWT encoder service customization](5-encoder-service.md)
 - [Extending JWTTokenAuthenticator](6-extending-jwt-authenticator.md)
+- [Creating JWT tokens programmatically](7-manual-token-creation.md)

--- a/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -9,6 +9,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 
 /**
@@ -43,8 +44,15 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
      */
     public function onAuthenticationSuccess(Request $request, TokenInterface $token)
     {
-        $user     = $token->getUser();
-        $jwt      = $this->jwtManager->create($user);
+        return $this->handleAuthenticationSuccess($token->getUser());
+    }
+
+    public function handleAuthenticationSuccess(UserInterface $user, $jwt = null)
+    {
+        if (null === $jwt) {
+            $jwt = $this->jwtManager->create($user);
+        }
+
         $response = new JWTAuthenticationSuccessResponse($jwt);
         $event    = new AuthenticationSuccessEvent(['token' => $jwt], $user, $response);
 

--- a/Tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/Tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
@@ -5,8 +5,8 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Security\Http\Authenticatio
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * AuthenticationSuccessHandlerTest.


### PR DESCRIPTION
This eases authenticating users programatically using:
 ```php
return $container
    ->get('lexik_jwt_authentication.handler.authentication_success')
    ->handleAuthenticationSuccess($user): Response;
```

or with a given jwt:
 ```php
$jwtManager = $container->get('lexik_jwt_authentication.jwt_manager');

return $container
    ->get('lexik_jwt_authentication.handler.authentication_success')
    ->handleAuthenticationSuccess($user, $jwtManaer->create($user));
```

Fixes #273 and https://github.com/lexik/LexikJWTAuthenticationBundle/issues/273#issuecomment-264449624.

- [x] Add `AuthenticationSuccessHandler::handleAuthenticationSuccess(): Response`
- [x] Document it + `JWTTokenManagerInterface::create($user)`