### PR TITLE
JWTUserProvider refreshUser method must return a User object

### DIFF
--- a/Security/User/JWTUserProvider.php
+++ b/Security/User/JWTUserProvider.php
@@ -51,6 +51,6 @@ final class JWTUserProvider implements UserProviderInterface
 
     public function refreshUser(UserInterface $user)
     {
-        // noop
+        return $user; // noop
     }
 }

--- a/Tests/Security/User/JWTUserProviderTest.php
+++ b/Tests/Security/User/JWTUserProviderTest.php
@@ -38,6 +38,7 @@ class JWTUserProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testRefreshUser()
     {
-        $this->assertNull((new JWTUserProvider(JWTUser::class))->refreshUser(new JWTUser('lexik')));
+        $user = new JWTUser('lexik');
+        $this->assertSame($user, (new JWTUserProvider(JWTUser::class))->refreshUser($user));
     }
 }


### PR DESCRIPTION
According to the [UserProviderInterface definition](http://api.symfony.com/3.2/Symfony/Component/Security/Core/User/UserProviderInterface.html#method_refreshUser), the refreshUser method should return an object implementing UserInterface.

This was returning null & causing an error when trying to chain multiple providers together.