### PR TITLE
Throw less missleading exception if SSL keys could not be loaded

### DIFF
--- a/Services/KeyLoader/OpenSSLKeyLoader.php
+++ b/Services/KeyLoader/OpenSSLKeyLoader.php
@@ -25,8 +25,15 @@ class OpenSSLKeyLoader extends AbstractKeyLoader
         );
 
         if (!$key) {
+            $sslError = '';
+            while ($msg = trim(openssl_error_string(), " \n\r\t\0\x0B\"")) {
+                if (substr($msg, 0, 6) === 'error:') {
+                    $msg = substr($msg, 6);
+                }
+                $sslError .= "\n ".$msg;
+            }
             throw new \RuntimeException(
-                sprintf('Failed to load %1$s key "%2$s". Did you correctly set the "lexik_jwt_authentication.jwt_%1$s_key_path" config option?', $type, $path)
+                sprintf('Failed to load %s key "%s": %s', $type, $path, $sslError)
             );
         }
 

--- a/Tests/Services/KeyLoader/OpenSSLKeyLoaderTest.php
+++ b/Tests/Services/KeyLoader/OpenSSLKeyLoaderTest.php
@@ -23,7 +23,11 @@ class OpenSSLKeyLoaderTest extends AbstractTestKeyLoader
 
     /**
      * @expectedException        \RuntimeException
-     * @expectedExceptionMessage Failed to load public key "public.pem".
+     * @expectedExceptionMessage Failed to load public key "public.pem":
+     *  0906D06C:PEM routines:PEM_read_bio:no start line
+     *  0906D06C:PEM routines:PEM_read_bio:no start line
+     *  0906D06C:PEM routines:PEM_read_bio:no start line
+     *  0906D06C:PEM routines:PEM_read_bio:no start line
      */
     public function testLoadInvalidPublicKey()
     {
@@ -34,7 +38,8 @@ class OpenSSLKeyLoaderTest extends AbstractTestKeyLoader
 
     /**
      * @expectedException        \RuntimeException
-     * @expectedExceptionMessage Failed to load private key "private.pem".
+     * @expectedExceptionMessage Failed to load private key "private.pem":
+     *  0906D06C:PEM routines:PEM_read_bio:no start line
      */
     public function testLoadInvalidPrivateKey()
     {


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |yes   |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |