### PR TITLE
Handle empty or null authorization header prefix, closes #310

### DIFF
--- a/TokenExtractor/AuthorizationHeaderTokenExtractor.php
+++ b/TokenExtractor/AuthorizationHeaderTokenExtractor.php
@@ -22,8 +22,8 @@ class AuthorizationHeaderTokenExtractor implements TokenExtractorInterface
     protected $name;
 
     /**
-     * @param string $prefix
-     * @param string $name
+     * @param string|null $prefix
+     * @param string      $name
      */
     public function __construct($prefix, $name)
     {
@@ -40,7 +40,13 @@ class AuthorizationHeaderTokenExtractor implements TokenExtractorInterface
             return false;
         }
 
-        $headerParts = explode(' ', $request->headers->get($this->name));
+        $authorizationHeader = $request->headers->get($this->name);
+
+        if (empty($this->prefix)) {
+            return $authorizationHeader;
+        }
+
+        $headerParts = explode(' ', $authorizationHeader);
 
         if (!(count($headerParts) === 2 && $headerParts[0] === $this->prefix)) {
             return false;


### PR DESCRIPTION
This PR handles cases where `token_extractors.authorization_header.prefix` is null (`~`) or empty (`""`)

```yaml
token_extractors:
    authorization_header:
        prefix: ~
        name: X-Auth-Token
```