### PR TITLE
feat: Share Token Extractor Config via parameters

### DIFF
--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -58,6 +58,9 @@ class LexikJWTAuthenticationExtension extends Extension
                 ->replaceArgument(1, $tokenExtractorsConfig['authorization_header']['name']);
 
             $map[] = new Reference($authorizationHeaderExtractorId);
+            $this->remapParametersNamespaces($tokenExtractorsConfig, $container, [
+                'authorization_header' => 'lexit_jwt_authentication.extractor.authorization_header.%s',
+            ]);
         }
 
         if ($tokenExtractorsConfig['query_parameter']['enabled']) {
@@ -67,6 +70,9 @@ class LexikJWTAuthenticationExtension extends Extension
                 ->replaceArgument(0, $tokenExtractorsConfig['query_parameter']['name']);
 
             $map[] = new Reference($queryParameterExtractorId);
+            $this->remapParametersNamespaces($tokenExtractorsConfig, $container, [
+                'query_parameter' => 'lexit_jwt_authentication.extractor.query_parameter.%s',
+            ]);
         }
 
         if ($tokenExtractorsConfig['cookie']['enabled']) {
@@ -76,8 +82,50 @@ class LexikJWTAuthenticationExtension extends Extension
                 ->replaceArgument(0, $tokenExtractorsConfig['cookie']['name']);
 
             $map[] = new Reference($cookieExtractorId);
+            $this->remapParametersNamespaces($tokenExtractorsConfig, $container, [
+                'cookie' => 'lexit_jwt_authentication.extractor.cookie.%s',
+            ]);
         }
 
         return $map;
+    }
+    /**
+     * @param array            $config
+     * @param ContainerBuilder $container
+     * @param array            $map
+     */
+    protected function remapParameters(array $config, ContainerBuilder $container, array $map)
+    {
+        foreach ($map as $name => $paramName) {
+            if (array_key_exists($name, $config)) {
+                $container->setParameter($paramName, $config[$name]);
+            }
+        }
+    }
+
+    /**
+     * @param array            $config
+     * @param ContainerBuilder $container
+     * @param array            $namespaces
+     */
+    protected function remapParametersNamespaces(array $config, ContainerBuilder $container, array $namespaces)
+    {
+        foreach ($namespaces as $ns => $map) {
+            if ($ns) {
+                if (!array_key_exists($ns, $config)) {
+                    continue;
+                }
+                $namespaceConfig = $config[$ns];
+            } else {
+                $namespaceConfig = $config;
+            }
+            if (is_array($map)) {
+                $this->remapParameters($namespaceConfig, $container, $map);
+            } else {
+                foreach ($namespaceConfig as $name => $value) {
+                    $container->setParameter(sprintf($map, $name), $value);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
I stumbled upon this issue, when I tried to make the LexikJWTAuthenticationBundle work with cookies. But I'll try to explain the issue in general terms:

I think it is a good idea to share the config parameters for the token extractors with other services and bundles via the DI container. It might be very useful for other bundles to know, under what name the CookieTokenExtractor is looking for the JWT string in the request. The same goes for the Authorization header and the Query String extractor.

So I propose to share these config namespaces in the DI container, the same way the friends of symfony do. They have created these two nifty little helper methods (remapParameters() & remapParametersNamespaces()) that let us easily write config values in the parameter namespace.