### PR TITLE
feat: Allow for Response Body without JWT Token

### DIFF
--- a/Response/JWTAuthenticationSuccessResponse.php
+++ b/Response/JWTAuthenticationSuccessResponse.php
@@ -26,20 +26,8 @@ final class JWTAuthenticationSuccessResponse extends JsonResponse
      * @param string $token Json Web Token
      * @param array  $data  Extra data passed to the response
      */
-    public function __construct($token, array $data = null)
+    public function __construct($token, array $data = [])
     {
-        $this->token = $token;
-
-        parent::__construct($data);
-    }
-
-    /**
-     * Sets the response data with the JWT included.
-     *
-     * {@inheritdoc}
-     */
-    public function setData($data = [])
-    {
-        parent::setData(['token' => $this->token] + (array) $data);
+        parent::__construct(['token' => $token] + $data);
     }
 }

--- a/Tests/Response/JWTAuthenticationSuccessResponseTest.php
+++ b/Tests/Response/JWTAuthenticationSuccessResponseTest.php
@@ -35,8 +35,8 @@ final class JWTAuthenticationSuccessResponseTest extends \PHPUnit_Framework_Test
         $response->setData($replacementData);
 
         // Test that the previous method call has no effect on the original body
-        $this->assertNotEquals(json_encode($replacementData), $response->getContent());
+        $this->assertEquals(json_encode($replacementData), $response->getContent());
         $this->assertAttributeSame($replacementData['foo'], 'foo', json_decode($response->getContent()));
-        $this->assertAttributeNotEmpty('token', json_decode($response->getContent()));
+        $this->assertFalse(isset(json_decode($response->getContent())->token));
     }
 }


### PR DESCRIPTION
This pull request is regarding Issue #313.

My proposed change would not change to current behavior of the bundle. All it does is respecting any changes being made to the response data during the AUTHENTICATION_SUCCESS event. That is, if an event listener decides to remove the token from the data array, it will no longer be added later. 