### PR TITLE
firewall provider name fixed.

### DIFF
--- a/Resources/doc/8-jwt-user-provider.md
+++ b/Resources/doc/8-jwt-user-provider.md
@@ -21,7 +21,7 @@ To work, the provider just needs a few lines of configuration:
 # app/config/security.yml
 security:
     providers:
-        jwt: # optional
+        jwt:
             lexik_jwt: ~
 ```
 

--- a/Resources/doc/8-jwt-user-provider.md
+++ b/Resources/doc/8-jwt-user-provider.md
@@ -21,7 +21,7 @@ To work, the provider just needs a few lines of configuration:
 # app/config/security.yml
 security:
     providers:
-        jwt: 
+        jwt: # optional
             lexik_jwt: ~
 ```
 
@@ -31,7 +31,7 @@ Then, use it on your JWT protected firewall:
 security:
     firewalls:
         api:
-            provider: lexik_jwt
+            provider: jwt
             guard:
                 # ...
 ```
@@ -70,8 +70,8 @@ final class User implements JWTUserInterface
     {
         return new self(
             $username,
-            $payload['roles'] // Added by default
-            $payload['email'] // Custom
+            $payload['roles'], // Added by default
+            $payload['email']  // Custom
         );
     }
 }


### PR DESCRIPTION
Hello,

I noticed little errors on documentation when trying to implement JWT my app and just updated for others don't struggle to figure out.

- Provider name was wrong, updated based on[ 1-configuration-reference.md#security-configuration](https://github.com/lexik/LexikJWTAuthenticationBundle/blob/master/Resources/doc/1-configuration-reference.md#security-configuration). 
- Syntax error fixed on User class example.