### PR TITLE
Moved mandatory dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "symfony/framework-bundle": "^2.8|^3.0",
         "symfony/security-bundle": "^2.8|^3.0",
         "symfony/console": "^2.8|^3.0",
-        "namshi/jose": "^7.2"
+        "namshi/jose": "^7.2",
+        "lcobucci/jwt": "~3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",
@@ -49,8 +50,7 @@
         "symfony/browser-kit": "^2.8|^3.0",
         "symfony/dom-crawler": "^2.8|^3.0",
         "symfony/yaml": "^2.8|^3.0",
-        "friendsofphp/php-cs-fixer": "^1.1",
-        "lcobucci/jwt": "~3.2"
+        "friendsofphp/php-cs-fixer": "^1.1"
     },
     "suggest": {
         "gesdinet/jwt-refresh-token-bundle": "Implements a refresh token system over Json Web Tokens in Symfony",


### PR DESCRIPTION
When using an instance of `lexik_jwt_authentication.encoder.lcobucci` an error message shows up:

```
  [Symfony\Component\Debug\Exception\ClassNotFoundException]                  
  Attempted to load class "Sha512" from namespace "Lcobucci\JWT\Signer\Rsa".  
  Did you forget a "use" statement for another namespace?
```

This error can be triggered if you did not install the dev-dependencies by simply retrieving the service from the container:

```php
$service = $this->getContainer()->get('lexik_jwt_authentication.encoder.lcobucci');
```

Moving the dependency fixes the issue.