### PR TITLE
Fix checkIssuedAt() to allow same-second value

### DIFF
--- a/Signature/LoadedJWS.php
+++ b/Signature/LoadedJWS.php
@@ -119,7 +119,7 @@ final class LoadedJWS
      */
     private function checkIssuedAt()
     {
-        if (isset($this->payload['iat']) && (int) $this->payload['iat'] > time()) {
+        if (isset($this->payload['iat']) && (int) $this->payload['iat'] >= time()) {
             return $this->state = self::INVALID;
         }
     }


### PR DESCRIPTION
Example case where strict comparison fails : generate a token programmatically and immediately call a route with it