### PR TITLE
Don't register lcobucci encoder if lcobucci/jwt is not installed

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection;
 
+use Lcobucci\JWT\Token;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -40,6 +41,12 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('service')
                             ->defaultValue('lexik_jwt_authentication.encoder.default')
+                            ->validate()
+                                ->ifTrue(function ($encoder) {
+                                    return 'lexik_jwt_authentication.encoder.lcobucci' === $encoder && !class_exists(Token::class);
+                                })
+                                ->thenInvalid('You must require "lcobucci/jwt" in your composer.json for using the lcobucci encoder.')
+                            ->end()
                         ->end()
                         ->scalarNode('signature_algorithm')
                             ->defaultValue('RS256')

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection;
 
+use Lcobucci\JWT\Token;
 use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\JWSProviderInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManagerInterface;
@@ -31,6 +32,11 @@ class LexikJWTAuthenticationExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        if (!class_exists(Token::class)) {
+            $container->removeDefinition('lexik_jwt_authentication.encoder.lcobucci');
+            $container->removeDefinition('lexik_jwt_authentication.jws_provider.lcobucci');
+        }
 
         $container->setParameter('lexik_jwt_authentication.private_key_path', $config['private_key_path']);
         $container->setParameter('lexik_jwt_authentication.public_key_path', $config['public_key_path']);


### PR DESCRIPTION
Replaces #349 
(test suite on symfony 3.4.x needs to be fixed beforehand)