### PR TITLE
Fix sf3.4 command autoregistration deprecation

### DIFF
--- a/LexikJWTAuthenticationBundle.php
+++ b/LexikJWTAuthenticationBundle.php
@@ -5,6 +5,7 @@ namespace Lexik\Bundle\JWTAuthenticationBundle;
 use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory\JWTFactory;
 use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory\JWTUserFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -27,5 +28,13 @@ class LexikJWTAuthenticationBundle extends Bundle
 
         $extension->addUserProviderFactory(new JWTUserFactory());
         $extension->addSecurityListenerFactory(new JWTFactory()); // BC 1.x, to be removed in 3.0
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerCommands(Application $application)
+    {
+        // noop
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -87,6 +87,11 @@
         </service>
         <service id="Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface" alias="lexik_jwt_authentication.extractor.chain_extractor" />
 
+        <!-- Console -->
+        <service id="lexik_jwt_authentication.check_config_command" class="Lexik\Bundle\JWTAuthenticationBundle\Command\CheckConfigCommand">
+            <tag name="console.command" command="lexik:jwt:check-config" />
+        </service>
+
         <!-- Deprecated -->
         <service id="lexik_jwt_authentication.security.authentication.provider" class="Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Provider\JWTProvider" public="false">
             <argument /> <!-- User Provider -->


### PR DESCRIPTION
Fixes:

> Auto-registration of the command "Lexik\Bundle\JWTAuthenticationBundle\Command\CheckConfigCommand" is deprecated since Symfony 3.4 and won't be supported in 4.0. Use PSR-4 based service discovery instead