### PR TITLE
Added setPayload to JWTDecodedEvent analogous to JWTCreatedEvent.

### DIFF
--- a/Event/JWTDecodedEvent.php
+++ b/Event/JWTDecodedEvent.php
@@ -41,7 +41,7 @@ class JWTDecodedEvent extends Event
     /**
      * @param array $payload
      */
-    public function setPayload($payload)
+    public function setPayload(array $payload)
     {
         $this->payload = $payload;
     }

--- a/Event/JWTDecodedEvent.php
+++ b/Event/JWTDecodedEvent.php
@@ -39,6 +39,14 @@ class JWTDecodedEvent extends Event
     }
 
     /**
+     * @param array $payload
+     */
+    public function setPayload($payload)
+    {
+        $this->payload = $payload;
+    }
+
+    /**
      * Mark payload as invalid.
      */
     public function markAsInvalid()


### PR DESCRIPTION
This is usefull to manipulate the payload after decoding. 

Example usage could be if attributes are encrypted while the JWTCreatedEvent is triggered and should be decrypted while decoding.