### PR TITLE
New Feature: Roles Defined Event

### DIFF
--- a/Event/JWTRolesDefinedEvent.php
+++ b/Event/JWTRolesDefinedEvent.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * JWTRolesDefinedEvent.
+ */
+class JWTRolesDefinedEvent extends Event
+{
+    /**
+     * @var UserInterface
+     */
+    protected $user;
+
+    /**
+     * @var array
+     */
+    protected $payload;
+
+    /**
+     * @var array
+     */
+    protected $roles;
+
+    /**
+     * JWTRolesDefinedEvent constructor.
+     * @param UserInterface $user
+     * @param array $payload
+     */
+    public function __construct(UserInterface $user, array $payload)
+    {
+        $this->payload = $payload;
+        $this->user   = $user;
+        $this->roles = $user->getRoles();
+    }
+
+    /**
+     * @return array
+     */
+    public function getPayload()
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @return UserInterface
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRoles()
+    {
+        return $this->roles;
+    }
+
+    /**
+     * @param array $roles
+     * @return JWTRolesDefinedEvent
+     */
+    public function setRoles($roles)
+    {
+        $this->roles = $roles;
+        return $this;
+    }
+}

--- a/Events.php
+++ b/Events.php
@@ -40,6 +40,12 @@ final class Events
     const JWT_DECODED = 'lexik_jwt_authentication.on_jwt_decoded';
 
     /**
+     * Dispatched before the JWTUserToken creation.
+     * Hook into this event to change the token roles using the payload and the user.
+     */
+    const JWT_ROLES_DEFINED = 'lexik_jwt_authentication.on_roles_defined';
+
+    /**
      * Dispatched after the token payload has been authenticated by the provider.
      * Hook into this event to perform additional modification to the authenticated token using the payload.
      */

--- a/Resources/doc/2-data-customization.md
+++ b/Resources/doc/2-data-customization.md
@@ -8,6 +8,7 @@ Table of contents
 
 * [Adding data to the JWT payload](#eventsjwt_created---adding-data-to-the-jwt-payload)
 * [Validating data in the JWT payload](#eventsjwt_decoded---validating-data-in-the-jwt-payload)
+* [Overriding your security token roles](#eventsjwt_roles_defined---Overriding your security token roles)
 * [Customize your security token](#eventsjwt_authenticated---customizing-your-security-token)
 * [Adding public data to the JWT response](#eventsauthentication_success---adding-public-data-to-the-jwt-response)
 * [Getting the JWT token string after encoding](#eventsjwt_encoded---getting-the-jwt-token-string-after-encoding)
@@ -136,6 +137,41 @@ public function onJWTDecoded(JWTDecodedEvent $event)
     if (!isset($payload['ip']) || $payload['ip'] !== $request->getClientIp()) {
         $event->markAsInvalid();
     }
+}
+```
+
+Events::JWT_ROLES_DEFINED - Overriding your security token roles
+----------------------------------------------------------------
+
+If you're working based on complex security requirements, you may need to also hook into the token roles definition. 
+
+``` yaml
+# services.yml
+services:
+    acme_api.event.jwt_roles_defined_listener:
+        class: AppBundle\EventListener\JWTRolesDefinedListener
+        tags:
+            - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_roles_defined, method: onJWTRolesDefined }
+```
+
+#### Example: Add roles from organization
+
+``` php
+// src/AppBundle/EventListener/JWTRolesDefinedListener.php
+
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTRolesDefinedEvent;
+
+/**
+ * @param JWTRolesDefinedEvent $event
+ *
+ * @return void
+ */
+public function onJWTRolesDefined(JWTRolesDefinedEvent $event)
+{
+    $user = $event->getUser();
+    $payload = $event->getPayload();
+    $organizationRoles = $payload['organizationRoles'];
+    $event->setRoles(array_merge($organizationRoles, $user->getRoles()))
 }
 ```
 

--- a/Security/Guard/JWTTokenAuthenticator.php
+++ b/Security/Guard/JWTTokenAuthenticator.php
@@ -223,7 +223,11 @@ class JWTTokenAuthenticator extends AbstractGuardAuthenticator
             throw new \RuntimeException('Unable to return an authenticated token since there is no pre authentication token.');
         }
 
-        $authToken = new JWTUserToken($user->getRoles(), $user, $preAuthToken->getCredentials(), $providerKey);
+        $rolesEvent = new JWTRolesDefinedEvent($user, $preAuthToken->getPayload());
+
+        $this->dispatcher->dispatch(Events::JWT_ROLES_DEFINED, $rolesEvent);
+
+        $authToken = new JWTUserToken($rolesEvent->getRoles(), $user, $preAuthToken->getCredentials(), $providerKey);
 
         $this->dispatcher->dispatch(Events::JWT_AUTHENTICATED, new JWTAuthenticatedEvent($preAuthToken->getPayload(), $authToken));
         $this->preAuthenticationTokenStorage->setToken(null);


### PR DESCRIPTION
This new event introduces a new functionality that allows to the Listeners/Subscribers to override the roles the `JWTUserToken` will have. It does it by saving state on an event and applying it to the token creation process.

This change is not API breaking, since the constructor of the event still defaults to the user roles for the token definition.

I also added the proper documentation for this change. Hope it can be merged! :)