### PR TITLE
Custom encoder documentation: encode & decode methods should properly throw exceptions

### DIFF
--- a/Resources/doc/5-encoder-service.md
+++ b/Resources/doc/5-encoder-service.md
@@ -15,6 +15,8 @@ namespace AppBundle\Encoder;
 
 use JWT\Authentication\JWT;
 use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTEncodeFailureException;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
 
 /**
  * NixillaJWTEncoder
@@ -41,7 +43,12 @@ class NixillaJWTEncoder implements JWTEncoderInterface
      */
     public function encode(array $data)
     {
-        return JWT::encode($data, $this->key);
+        try {
+            return JWT::encode($data, $this->key);
+        }
+        catch (\Exception $e) {
+            throw new JWTEncodeFailureException(JWTEncodeFailureException::INVALID_CONFIG, 'An error occurred while trying to encode the JWT token.', $e);
+        }
     }
 
     /**
@@ -52,7 +59,7 @@ class NixillaJWTEncoder implements JWTEncoderInterface
         try {
             return (array) JWT::decode($token, $this->key);
         } catch (\Exception $e) {
-            return false;
+            throw new JWTDecodeFailureException(JWTDecodeFailureException::INVALID_TOKEN, 'Invalid JWT Token', $e);
         }
     }
 }


### PR DESCRIPTION
...instead of failing silently

I also ensured that the `encode` method throws a proper `JWTEncodeFailureException` exception (just like it's done in the [default encoder](https://github.com/lexik/LexikJWTAuthenticationBundle/blob/master/Encoder/DefaultEncoder.php#L37)). For instance, a `\DomainException` could be thrown in the `\JWT\Authentication\JWT::sign` method if an incorrect algo is provided. Mostly to highlight the fact that generic exceptions should be caught and converted into `JWT(Encode|Decode)FailureException`s.

Closes #431