### PR TITLE
updated installation guide

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -32,8 +32,15 @@ Generate the SSH keys :
 
 ``` bash
 $ mkdir -p var/jwt # For Symfony3+, no need of the -p option
-$ openssl genrsa -out var/jwt/private.pem -aes256 4096
-$ openssl rsa -pubout -in var/jwt/private.pem -out var/jwt/public.pem
+$ openssl genrsa -out config/jwt/private.pem -aes256 4096
+$ openssl rsa -pubout -in config/jwt/private.pem -out config/jwt/public.pem
+```
+
+In case first ```openssl``` command forces you to input password use following to get the private key decrypted
+``` bash
+$ openssl rsa -in config/jwt/private.pem -out config/jwt/private2.pem
+$ mv config/jwt/private.pem config/jwt/private.pem-back
+$ mv config/jwt/private2.pem config/jwt/private.pem
 ```
 
 Configuration


### PR DESCRIPTION
New version of openssl generates encrypted private keys which are unusable. I had too look for a way go decrypt it. This gave me a little headache. 