### PR TITLE
Update index.md - Remove reference to lafourchette.

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -159,7 +159,7 @@ This may not be a problem depending on the system that makes calls to your API (
 
 #### Impersonation
 
-For impersonating users using JWT, see [lafourchette/SwitchUserStatelessBundle](https://github.com/lafourchette/SwitchUserStatelessBundle), a stateless replacement of the `switch_user` listener.
+For impersonating users using JWT, see https://symfony.com/doc/current/security/impersonating_user.html 
 
 #### Important note for Apache users
 


### PR DESCRIPTION
Change to the documentation as [lafourchette/SwitchUserStatelessBundle](https://github.com/lafourchette/SwitchUserStatelessBundle) no longer appears to be maintained and is no longer necessary since this pull request https://github.com/symfony/symfony/pull/24260