### PR TITLE
Add a `lexik:jwt:generate-token` command

### DIFF
--- a/Command/GenerateTokenCommand.php
+++ b/Command/GenerateTokenCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Command;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * GenerateTokenCommand.
+ *
+ * @author Samuel Roze <samuel.roze@gmail.com>
+ */
+class GenerateTokenCommand extends Command
+{
+    protected static $defaultName = 'lexik:jwt:generate-token';
+
+    private $tokenManager;
+
+    /** @var \Traversable|UserProviderInterface[] */
+    private $userProviders;
+
+    public function __construct(JWTTokenManagerInterface $tokenManager, \Traversable $userProviders)
+    {
+        parent::__construct();
+
+        $this->tokenManager  = $tokenManager;
+        $this->userProviders = $userProviders;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName(static::$defaultName)
+            ->setDescription('Generates a JWT token')
+            ->addArgument('username', InputArgument::REQUIRED)
+            ->addOption('user-class', 'c', InputOption::VALUE_REQUIRED)
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->userProviders instanceof \Countable && 0 === \count($this->userProviders)) {
+            throw new \RuntimeException('You must have at least 1 configured user provider to generate a token.');
+        }
+
+        if (!$userClass = $input->getOption('user-class')) {
+            if (1 < \count($userProviders = iterator_to_array($this->userProviders))) {
+                throw new \RuntimeException('The "--user-class" option must be passed as there is more than 1 configured user provider.');
+            }
+
+            $userProvider = current($userProviders);
+        } else {
+            $userProvider = null;
+
+            foreach ($this->userProviders as $provider) {
+                if ($provider->supportsClass($userClass)) {
+                    $userProvider = $provider;
+
+                    break;
+                }
+            }
+
+            if (!$userProvider) {
+                throw new \RuntimeException(sprintf('There is no configured user provider for class "%s".', $userClass));
+            }
+        }
+
+        $token = $this->tokenManager->create(
+            $userProvider->loadUserByUsername($input->getArgument('username'))
+        );
+
+        $output->writeln([
+            '',
+            '<info>'.$token.'</info>',
+            '',
+        ]);
+    }
+}

--- a/DependencyInjection/Compiler/WireGenerateTokenCommandPass.php
+++ b/DependencyInjection/Compiler/WireGenerateTokenCommandPass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class WireGenerateTokenCommandPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('lexik_jwt_authentication.generate_token_command') || !$container->hasDefinition('security.context_listener')) {
+            return;
+        }
+
+        $container
+            ->getDefinition('lexik_jwt_authentication.generate_token_command')
+            ->replaceArgument(1, $container->getDefinition('security.context_listener')->getArgument(1))
+        ;
+    }
+}

--- a/LexikJWTAuthenticationBundle.php
+++ b/LexikJWTAuthenticationBundle.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle;
 
+use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Compiler\WireGenerateTokenCommandPass;
 use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory\JWTFactory;
 use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory\JWTUserFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
@@ -22,6 +23,8 @@ class LexikJWTAuthenticationBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+
+        $container->addCompilerPass(new WireGenerateTokenCommandPass());
 
         /** @var SecurityExtension $extension */
         $extension = $container->getExtension('security');

--- a/Resources/config/console.xml
+++ b/Resources/config/console.xml
@@ -10,6 +10,12 @@
             <argument type="string">%lexik_jwt_authentication.encoder.signature_algorithm%</argument> <!-- signature algorithm -->
             <tag name="console.command" command="lexik:jwt:check-config" />
         </service>
+
+        <service id="lexik_jwt_authentication.generate_token_command" class="Lexik\Bundle\JWTAuthenticationBundle\Command\GenerateTokenCommand" public="true">
+            <argument type="service" id="lexik_jwt_authentication.jwt_manager" />
+            <argument type="collection" /> <!-- user providers -->
+            <tag name="console.command" command="lexik:jwt:generate-token" />
+        </service>
     </services>
 
 </container>

--- a/Tests/Functional/Command/GenerateTokenCommandTest.php
+++ b/Tests/Functional/Command/GenerateTokenCommandTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\Command;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\TestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Security\Core\User\User;
+
+class GenerateTokenCommandTest extends TestCase
+{
+    public function testRun()
+    {
+        $tester = new CommandTester((new Application($this->bootKernel(['test_case' => 'GenerateTokenCommand'])))->get('lexik:jwt:generate-token'));
+
+        $this->assertSame(0, $tester->execute(['username' => 'lexik', '--user-class' => User::class]));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The "--user-class" option must be passed as there is more than 1 configured user provider.
+     */
+    public function testRunWithoutSpecifiedProviderAndMoreThanOneConfigured()
+    {
+        $tester = new CommandTester((new Application($this->bootKernel(['test_case' => 'GenerateTokenCommand'])))->get('lexik:jwt:generate-token'));
+
+        $this->assertSame(0, $tester->execute(['username' => 'lexik']));
+    }
+}

--- a/Tests/Functional/TestCase.php
+++ b/Tests/Functional/TestCase.php
@@ -20,7 +20,7 @@ abstract class TestCase extends WebTestCase
     {
         require_once __DIR__.'/app/AppKernel.php';
 
-        return new AppKernel('test', true);
+        return new AppKernel('test', true, isset($options['test_case']) ? $options['test_case'] : null);
     }
 
     protected static function createAuthenticatedClient($token = null)

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -18,10 +18,14 @@ class AppKernel extends Kernel
 
     private $signatureAlgorithm;
 
-    public function __construct($environment, $debug)
+    private $testCase;
+
+    public function __construct($environment, $debug, $testCase = null)
     {
         parent::__construct($environment, $debug);
 
+
+        $this->testCase           = $testCase;
         $this->encoder            = getenv('ENCODER') ?: 'default';
         $this->userProvider       = getenv('PROVIDER') ?: 'in_memory';
         $this->signatureAlgorithm = getenv('ALGORITHM');
@@ -66,6 +70,12 @@ class AppKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
+        if ($this->testCase && file_exists(__DIR__.'/config/'.$this->testCase.'/config.yml')) {
+            $loader->load(__DIR__.'/config/'.$this->testCase.'/config.yml');
+
+            return;
+        }
+
         $loader->load(__DIR__.sprintf('/config/security_%s.yml', $this->userProvider));
 
         if ($this->signatureAlgorithm && file_exists($file = __DIR__.sprintf('/config/config_%s_%s.yml', $this->encoder, strtolower($this->signatureAlgorithm)))) {

--- a/Tests/Functional/app/config/GenerateTokenCommand/config.yml
+++ b/Tests/Functional/app/config/GenerateTokenCommand/config.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: '../base_config.yml' }
+    - { resource: '../security_in_memory.yml' }
+
+lexik_jwt_authentication:
+    secret_key: testing
+    encoder:
+        signature_algorithm: 'HS256'
+        service: lexik_jwt_authentication.encoder.lcobucci


### PR DESCRIPTION
For debugging purposes (and more depending on how the tokens are used - i.e. as API keys for example) it's very useful to be able to generate tokens... therefore let's ship a command that does that 👍 