### PR TITLE
index.md: Change openssl command to not ask for passphrase

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -32,15 +32,8 @@ Generate the SSH keys :
 
 ``` bash
 $ mkdir -p config/jwt # For Symfony3+, no need of the -p option
-$ openssl genrsa -out config/jwt/private.pem -aes256 4096
+$ openssl genrsa -out config/jwt/private.pem 4096
 $ openssl rsa -pubout -in config/jwt/private.pem -out config/jwt/public.pem
-```
-
-In case first ```openssl``` command forces you to input password use following to get the private key decrypted
-``` bash
-$ openssl rsa -in config/jwt/private.pem -out config/jwt/private2.pem
-$ mv config/jwt/private.pem config/jwt/private.pem-back
-$ mv config/jwt/private2.pem config/jwt/private.pem
 ```
 
 Configuration


### PR DESCRIPTION
The -aes256 option means the key will be encrypted with aes using a passphrase,
removing this option means openssl won't ask for a passphrase and the extra step
of taking the key trough openssl again becomes unnecessary.