### PR TITLE
Update documentation for v2.5 / Symfony 4

### DIFF
--- a/Resources/doc/1-configuration-reference.md
+++ b/Resources/doc/1-configuration-reference.md
@@ -6,51 +6,61 @@ Bundle configuration
 
 ### Minimal configuration
 
+#### Using RSA/ECDSA
+
 ``` yaml
-# app/config/config.yml
+# config/packages/lexik_jwt_authentication.yaml
 #...
 lexik_jwt_authentication:
-    private_key_path:    '%kernel.root_dir%/../config/jwt/private.pem'
-    # ssh public key path
-    public_key_path:     '%kernel.root_dir%/../config/jwt/public.pem'
-    # ssh key pass phrase
-    pass_phrase:         ''
+    secret_key: '%kernel.project_dir%/config/jwt/private.pem' # path to the secret key OR raw secret key, required for creating tokens
+    public_key: '%kernel.project_dir%/config/jwt/public.pem'  # path to the public key OR raw public key, required for verifying tokens
+    pass_phrase: 'yourpassphrase' # required for creating tokens
+```
+
+#### Using HMAC
+``` yaml
+#  config/packages/lexik_jwt_authentication.yaml
+#...
+lexik_jwt_authentication:
+    secret_key: yoursecret
 ```
 
 ### Full default configuration
 
 ``` yaml
-# app/config/config.yml
+# config/packages/lexik_jwt_authentication.yaml
 # ...
 lexik_jwt_authentication:
-    # ssh private key path
-    private_key_path:    '%kernel.root_dir%/../config/jwt/private.pem'
-    # ssh public key path
-    public_key_path:     '%kernel.root_dir%/../config/jwt/public.pem'
-    # ssh key pass phrase
-    pass_phrase:         ''
-    # token ttl
-    token_ttl:           3600
-    # key under which the user identity will be stored in the token payload
-    user_identity_field: username
+    secret_key: ~
+    public_key: ~
+    pass_phrase: ~
+    token_ttl: 3600 # token TTL in seconds, defaults to 1 hour
+    user_identity_field: username  # key under which the user identity will be stored in the token payload
+    clock_skew: 0
 
     # token encoding/decoding settings
     encoder:
-        # token encoder/decoder service - default implementation based on the namshi/jose library
+        # token encoder/decoder service - default implementation based on the lcobucci/jwt library
         service:            lexik_jwt_authentication.encoder.lcobucci
+
         # encryption algorithm used by the encoder service
         signature_algorithm: RS256
 
     # token extraction settings
     token_extractors:
-        authorization_header:      # look for a token as Authorization Header
+        # look for a token as Authorization Header
+        authorization_header:
             enabled: true
             prefix:  Bearer
             name:    Authorization
-        cookie:                    # check token in a cookie
+
+        # check token in a cookie
+        cookie:
             enabled: false
             name:    BEARER
-        query_parameter:           # check token in query string parameter
+            
+        # check token in query string parameter
+        query_parameter:
             enabled: false
             name:    bearer
 ```
@@ -59,42 +69,32 @@ lexik_jwt_authentication:
 
 ##### service
 
-Default to `lexik_jwt_authentication.encoder.default` which is based on the [Namshi/JOSE](https://github.com/namshi/jose) library.  
-You can also use `lexik_jwt_authentication.encoder.lcobucci` which is based on the [Lcobucci/JWT](https://github.com/lcobucci/jwt) library and concern the same usage level as the default one, providing an easy way to validate claims.
+Defaults to `lexik_jwt_authentication.encoder.lcobucci` which is based on the [Lcobucci/JWT](https://github.com/lcobucci/jwt) library.
 
-For an advanced token encoding with higher encryption support, please see the [`Spomky-Labs/lexik-jose-bridge`](https://github.com/Spomky-Labs/lexik-jose-bridge) which is based on the great [`Spomky-Labs/JOSE`](https://github.com/Spomky-Labs/JOSE) library.
+For an advanced token encoding with higher encryption support, please see the [Spomky-Labs/lexik-jose-bridge](https://github.com/Spomky-Labs/lexik-jose-bridge) which is based on the great [web-token/jwt-framework](https://github.com/web-token/jwt-framework) library.
 
 To create your own encoder service, see the [JWT encoder service customization chapter](5-encoder-service.md).
-
-##### crypto_engine
-
-One of `openssl` and `phpseclib`, the crypto engines supported by the default token encoder service.  
-See the [OpenSSL](https://github.com/openssl/openssl) and [phpseclib](https://github.com/phpseclib/phpseclib) documentations for more information.
 
 ##### signature_algorithm
 
 One of the algorithms supported by the default encoder for the configured [crypto engine](#crypto_engine).
 
-__Supported algorithms for OpenSSL:__
+- HS256, HS384, HS512 (HMAC)
 - RS256, RS384, RS512 (RSA)
 - ES256, ES384, ES512 (ECDSA)
-- HS256, HS384, HS512 (HMAC)
-
-__Supported algorithms for phpseclib:__
-- RS256, RS384, RS512 (RSA)
 
 Security configuration
 -----------------------
 
 ```yaml
-# app/config/security.yml
+# config/packages/security.yaml
 security:
     # ...
     providers:
         # ...
-        jwt: # optional
+        jwt: # optional, any user provider can be used
             lexik_jwt:
-                class: AppBundle\Security\JWTUser
+                class: App\Security\JWTUser
     firewalls:
         # ...
         api:

--- a/Resources/doc/2-data-customization.md
+++ b/Resources/doc/2-data-customization.md
@@ -25,10 +25,10 @@ but you can add your own data.
 You can also modify the header to fit on your application context.
 
 ``` yaml
-# services.yml
+# config/services.yaml
 services:
     acme_api.event.jwt_created_listener:
-        class: AppBundle\EventListener\JWTCreatedListener
+        class: App\EventListener\JWTCreatedListener
         arguments: [ '@request_stack' ]
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_created, method: onJWTCreated }
@@ -37,7 +37,7 @@ services:
 #### Example: Add client ip to the encoded payload
 
 ``` php
-// src/AppBundle/EventListener/JWTCreatedListener.php
+// src/App/EventListener/JWTCreatedListener.php
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -79,7 +79,7 @@ public function onJWTCreated(JWTCreatedEvent $event)
 #### Example: Override token expiration date calculation to be more flexible
 
 ``` php
-// src/AppBundle/EventListener/JWTCreatedListener.php
+// src/App/EventListener/JWTCreatedListener.php
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
 
@@ -106,10 +106,10 @@ Events::JWT_DECODED - Validating data in the JWT payload
 You can access the jwt payload once it has been decoded to perform you own additional validation.
 
 ``` yaml
-# services.yml
+# config/services.yaml
 services:
     acme_api.event.jwt_decoded_listener:
-        class: AppBundle\EventListener\JWTDecodedListener
+        class: App\EventListener\JWTDecodedListener
         arguments: [ '@request_stack' ]
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_decoded, method: onJWTDecoded }
@@ -118,7 +118,7 @@ services:
 #### Example: Check client ip the decoded payload (from example 1)
 
 ``` php
-// src/AppBundle/EventListener/JWTDecodedListener.php
+// src/App/EventListener/JWTDecodedListener.php
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTDecodedEvent;
 
@@ -145,10 +145,10 @@ Events::JWT_AUTHENTICATED - Customizing your security token
 You can add attributes to the token once it has been authenticated to allow JWT properties to be used by your application.
 
 ``` yaml
-# services.yml
+# config/services.yaml
 services:
     acme_api.event.jwt_authenticated_listener:
-        class: AppBundle\EventListener\JWTAuthenticatedListener
+        class: App\EventListener\JWTAuthenticatedListener
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_authenticated, method: onJWTAuthenticated }
 ```
@@ -156,7 +156,7 @@ services:
 #### Example: Keep a UUID that was set into the JWT in the authenticated token
 
 ``` php
-// src/AppBundle/EventListener/JWTAuthenticatedListener.php
+// src/App/EventListener/JWTAuthenticatedListener.php
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTAuthenticatedEvent;
 
@@ -180,10 +180,10 @@ Events::AUTHENTICATION_SUCCESS - Adding public data to the JWT response
 By default, the authentication response is just a json containing the JWT but you can add your own public data to it.
 
 ``` yaml
-# services.yml
+# config/services.yaml
 services:
     acme_api.event.authentication_success_listener:
-        class: AppBundle\EventListener\AuthenticationSuccessListener
+        class: App\EventListener\AuthenticationSuccessListener
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: onAuthenticationSuccessResponse }
 ```
@@ -191,7 +191,7 @@ services:
 #### Example: Add user roles to the response body
 
 ``` php
-// src/AppBundle/EventListener/AuthenticationSuccessListener.php
+// src/App/EventListener/AuthenticationSuccessListener.php
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
 
@@ -223,7 +223,7 @@ You may need to get JWT after its creation.
 #### Example: Obtain JWT string
 
 ``` php
-// src/AppBundle/EventListener/JWTEncodedListener.php
+// src/App/EventListener/JWTEncodedListener.php
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent;
 
@@ -242,10 +242,10 @@ Events::AUTHENTICATION_FAILURE - Customizing the failure response body
 By default, the response in case of failed authentication is just a json containing a failure message and a 401 status code, but you can set a custom response.
 
 ``` yaml
-# services.yml
+# config/services.yaml
 services:
     acme_api.event.authentication_failure_listener:
-        class: AppBundle\EventListener\AuthenticationFailureListener
+        class: App\EventListener\AuthenticationFailureListener
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_failure, method: onAuthenticationFailureResponse }
 ```
@@ -253,7 +253,7 @@ services:
 Example: Set a custom response on authentication failure
 
 ``` php
-// src/AppBundle/EventListener/AuthenticationFailureListener.php
+// src/App/EventListener/AuthenticationFailureListener.php
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationFailureEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
@@ -280,10 +280,10 @@ Events::JWT_INVALID - Customizing the invalid token response
 By default, if the token is invalid, the response is just a json containing the corresponding error message and a 401 status code, but you can set a custom response.
 
 ``` yaml
-# services.yml
+# config/services.yaml
 services:
     acme_api.event.jwt_invalid_listener:
-        class: AppBundle\EventListener\JWTInvalidListener
+        class: App\EventListener\JWTInvalidListener
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_invalid, method: onJWTInvalid }
 ```
@@ -291,7 +291,7 @@ services:
 #### Example: Set a custom response message and status code on invalid token
 
 ``` php
-// src/AppBundle/EventListener/JWTInvalidListener.php
+// src/App/EventListener/JWTInvalidListener.php
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
@@ -314,10 +314,10 @@ By default, if no token is found in a request, the authentication listener will 
 Thanks to this event, you can set a custom response.
 
 ``` yaml
-# services.yml
+# config/services.yaml
 services:
     acme_api.event.jwt_invalid_listener:
-        class: AppBundle\EventListener\JWTInvalidListener
+        class: App\EventListener\JWTInvalidListener
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_not_found, method: onJWTNotFound }
 ```
@@ -325,7 +325,7 @@ services:
 #### Example: Set a custom response message on token not found
 
 ``` php
-// src/AppBundle/EventListener/JWTNotFoundListener.php
+// src/App/EventListener/JWTNotFoundListener.php
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTNotFoundEvent;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -353,10 +353,10 @@ By default, if the token provided in the request is expired, the authentication 
 Thanks to this event, you can set a custom response or simply change the response message.
 
 ``` yaml
-# services.yml
+# config/services.yaml
 services:
     acme_api.event.jwt_expired_listener:
-        class: AppBundle\EventListener\JWTExpiredListener
+        class: App\EventListener\JWTExpiredListener
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_expired, method: onJWTExpired }
 ```
@@ -364,7 +364,7 @@ services:
 #### Example: Customize the response in case of expired token
 
 ``` php
-// src/AppBundle/EventListener/JWTExpiredListener.php
+// src/App/EventListener/JWTExpiredListener.php
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTExpiredEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
@@ -382,4 +382,4 @@ public function onJWTExpired(JWTExpiredEvent $event)
 ```
 
 __Protip:__ You might want to use the same method for customizing the response on both `JWT_INVALID`, `JWT_NOT_FOUND` and/or `JWT_EXPIRED` events. 
-For that, use the `Lexik\Bundle\JWTAuthenticationBundle\Event\JWTFailureEventInterface` interface to type-hint the event argument of your listener's method, rather the class corresponding to one of these specific events.
+For that, use the `Lexik\Bundle\JWTAuthenticationBundle\Event\JWTFailureEventInterface` interface to type-hint the event argument of your listener's method instead of the concrete class corresponding to one of these specific events.

--- a/Resources/doc/3-functional-testing.md
+++ b/Resources/doc/3-functional-testing.md
@@ -4,7 +4,7 @@ Functionally testing a JWT protected api
 Configuration
 -------------
 
-Generate some test specific keys, for example :
+Generate some test specific keys, for example:
 
 ``` bash
 $ openssl genrsa -out config/jwt/private-test.pem -aes256 4096
@@ -14,10 +14,10 @@ $ openssl rsa -pubout -in config/jwt/private-test.pem -out config/jwt/public-tes
 Override the bundle configuration in your `config_test.yml` :
 
 ``` yaml
-# config_test.yml
+# config/test/lexik_jwt_authentication.yaml
 lexik_jwt_authentication:
-    private_key_path:   '%kernel.root_dir%/../config/jwt/private-test.pem'
-    public_key_path:    '%kernel.root_dir%/../config/jwt/public-test.pem'
+    secret_key: '%kernel.project_dir%/config/jwt/private-test.pem'
+    public_key: '%kernel.project_dir%/config/jwt/public-test.pem'
 ```
 
 **Protip:** You might want to commit those keys if you intend to run your test on a ci server.

--- a/Resources/doc/4-cors-requests.md
+++ b/Resources/doc/4-cors-requests.md
@@ -2,7 +2,7 @@ Working with CORS requests
 ==========================
 
 There are several ways to add CORS requests handling capabilities to a Symfony application,
-the fastest and most flexible solution being the [`NelmioCorsBundle`](https://github.com/nelmio/NelmioCorsBundle).
+the fastest and most flexible solution being the [NelmioCorsBundle](https://github.com/nelmio/NelmioCorsBundle).
 
 This bundle allows you to enable and configure CORS rules very precisely without having to modify your server configuration.
 See the documentation for installation and usage instructions.

--- a/Resources/doc/5-encoder-service.md
+++ b/Resources/doc/5-encoder-service.md
@@ -10,8 +10,8 @@ Creating your own encoder
 ### Create the encoder class
 
 ``` php
-// src/AppBundle/Encoder/NixillaJWTEncoder.php
-namespace AppBundle\Encoder;
+// src/App/Encoder/NixillaJWTEncoder.php
+namespace App\Encoder;
 
 use JWT\Authentication\JWT;
 use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
@@ -25,15 +25,9 @@ use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
  */
 class NixillaJWTEncoder implements JWTEncoderInterface
 {
-    /**
-     * @var string
-     */
-    protected $key;
+    private $key;
 
-    /**
-     * __construct
-     */
-    public function __construct($key = 'super_secret_key')
+    public function __construct(string $key = 'super_secret_key')
     {
         $this->key = $key;
     }
@@ -68,16 +62,16 @@ class NixillaJWTEncoder implements JWTEncoderInterface
 ### Declare it as a service
 
 ``` yaml
-# services.yml
+# config/services.yaml
 services:
     acme_api.encoder.nixilla_jwt_encoder:
-        class: AppBundle\Encoder\NixillaJWTEncoder
+        class: App\Encoder\NixillaJWTEncoder
 ```
 
 ### Use it as encoder service
 
 ``` yaml
-# config.yml
+# config/packages/lexik_jwt_authentication.yaml
 lexik_jwt_authentication:
     # ...
     encoder:

--- a/Resources/doc/6-extending-jwt-authenticator.md
+++ b/Resources/doc/6-extending-jwt-authenticator.md
@@ -11,7 +11,7 @@ The following code can be used for creating your own authenticators.
 Create the authenticator class extending the built-in one:
 
 ```php
-namespace AppBundle\Security\Guard;
+namespace App\Security\Guard;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Guard\JWTTokenAuthenticator as BaseAuthenticator;
 
@@ -24,17 +24,17 @@ class JWTTokenAuthenticator extends BaseAuthenticator
 Same for the service definition:
 
 ```yaml
-# services.yml
+# config/services.yaml
 services:
     app.jwt_token_authenticator:
-        class: AppBundle\Security\Guard\JWTTokenAuthenticator
+        class: App\Security\Guard\JWTTokenAuthenticator
         parent: lexik_jwt_authentication.security.guard.jwt_token_authenticator
 ```
 
 Then, use it in your security configuration:
 
 ```yaml
-# app/config/security.yml
+# config/packages/security.yaml
 security:
     # ...
     firewalls:
@@ -58,7 +58,7 @@ If your application contains multiple firewalls with different security contexts
 
 
 ```php
-namespace AppBundle\Security\Guard;
+namespace App\Security\Guard;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Guard\JWTTokenAuthenticator as BaseAuthenticator;
 use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor;

--- a/Resources/doc/7-manual-token-creation.md
+++ b/Resources/doc/7-manual-token-creation.md
@@ -5,7 +5,7 @@ It might be useful in many cases to manually create a JWT token for a given user
 To achieve this, use the `lexik_jwt_authentication.jwt_manager` service directly:
 
 ```php
-namespace AppBundle\Controller;
+namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/Resources/doc/8-jwt-user-provider.md
+++ b/Resources/doc/8-jwt-user-provider.md
@@ -18,7 +18,7 @@ Configuring the user provider
 To work, the provider just needs a few lines of configuration:
 
 ```yaml
-# app/config/security.yml
+# config/packages/security.yaml
 security:
     providers:
         jwt:
@@ -53,7 +53,7 @@ the JWT token payload as arguments and returns an instance of the class.
 ##### Sample implementation
 
 ```php
-namespace AppBundle\Security;
+namespace App\Security;
 
 final class User implements JWTUserInterface
 {
@@ -82,12 +82,12 @@ _Note_:  You can extend the default `JWTUser` class if that fits your needs.
 ##### Configuration
 
 ```yaml
-# app/config/security.yml
+# config/packages/security.yaml
 providers:
     # ...
     jwt:
         lexik_jwt:
-            class: AppBundle\Security\User
+            class: App\Security\User
 ```
 
 And voilà!

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -4,7 +4,7 @@ Getting started
 Prerequisites
 -------------
 
-This bundle requires Symfony 2.8+ (and the OpenSSL library if you intend to use the default provided encoder).
+This bundle requires Symfony 3.4+ and the openssl extension.
 
 **Protip:** Though the bundle doesn't enforce you to do so, it is highly recommended to use HTTPS. 
 
@@ -46,26 +46,17 @@ $ mv config/jwt/private2.pem config/jwt/private.pem
 Configuration
 -------------
 
-Configure the SSH keys path in your `config.yml` :
+Configure the SSH keys path in your `config/packages/lexik_jwt_authentication.yaml` :
 
 ``` yaml
 lexik_jwt_authentication:
-    secret_key:       '%jwt_private_key_path%' # required for token creation
-    public_key:       '%jwt_public_key_path%'  # required for token verification
-    pass_phrase:      '%jwt_key_pass_phrase%'  # required for token creation
-    token_ttl:        '%jwt_token_ttl%'
+    secret_key:       '%kernel.project_dir%/config/jwt/private.pem' # required for token creation
+    public_key:       '%kernel.project_dir%/config/jwt/public.pem'  # required for token verification
+    pass_phrase:      'your_secret_passphrase' # required for token creation, usage of an environment variable is recommended
+    token_ttl:        3600
 ```
 
-Configure your `parameters.yml` :
-
-``` yaml
-jwt_private_key_path: '%kernel.root_dir%/../config/jwt/private.pem'
-jwt_public_key_path:  '%kernel.root_dir%/../config/jwt/public.pem'
-jwt_key_pass_phrase:  'your_secret_passphrase'
-jwt_token_ttl:        3600
-```
-
-Configure your `security.yml` :
+Configure your `config/packages/security.yaml` :
 
 ``` yaml
 security:
@@ -77,11 +68,10 @@ security:
             pattern:  ^/api/login
             stateless: true
             anonymous: true
-            form_login:
+            json_login:
                 check_path:               /api/login_check
                 success_handler:          lexik_jwt_authentication.handler.authentication_success
                 failure_handler:          lexik_jwt_authentication.handler.authentication_failure
-                require_previous_session: false
 
         api:
             pattern:   ^/api
@@ -118,7 +108,7 @@ Store it (client side), the JWT is reusable until its ttl has expired (3600 seco
 Note: You can test getting the token with a simple curl command like this:
 
 ```bash
-curl -X POST http://localhost:8000/api/login_check -d _username=johndoe -d _password=test
+curl -X POST -H "Content-Type: application/json" http://localhost:8000/api/login_check -d '{"username":"johndoe","password":"test"}'
 ```
 
 If it works, you will receive something like this:


### PR DESCRIPTION
First round of documentation updates.
Includes:

- config file paths according to the Symfony 4 directory structure
- use of `json_login` instead of `form_login`
- use of `HMAC` based signer

and other misc changes