### PR TITLE
Make openssl key loader service deprecated

### DIFF
--- a/Resources/config/key_loader.xml
+++ b/Resources/config/key_loader.xml
@@ -10,7 +10,9 @@
             <argument/> <!-- public key -->
             <argument>%lexik_jwt_authentication.pass_phrase%</argument>
         </service>
-        <service id="lexik_jwt_authentication.key_loader.openssl" class="Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\OpenSSLKeyLoader" parent="lexik_jwt_authentication.key_loader.abstract"/>
+        <service id="lexik_jwt_authentication.key_loader.openssl" class="Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\OpenSSLKeyLoader" parent="lexik_jwt_authentication.key_loader.abstract">
+            <deprecated>The "%service_id%" service is deprecated since version 2.5 and will be removed in 3.0. Use lexik_jwt_authentication.key_loader.raw instead.</deprecated>
+        </service>
         <service id="lexik_jwt_authentication.key_loader.raw" class="Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\RawKeyLoader" parent="lexik_jwt_authentication.key_loader.abstract"/>
     </services>
 </container>


### PR DESCRIPTION
Service OpenSSLKeyLoader is deprecated since version 2.5. It triggers
deprecation error as soon as someone tries to include it. Symfony
framework tries to create reflection of it while building the container
and it triggers deprecation as well. Symfony doesn't know anything about this
service being deprecated. Service should be declared as deprecated in
service config, then Symfony won't touch it.

[https://github.com/lexik/LexikJWTAuthenticationBundle/issues/523]