### PR TITLE
Customizable User ID Claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 CHANGELOG
 =========
 
-For a diff between two versions https://github.com/lexik/LexikJWTAuthenticationBundle/compare/v1.0.0...v2.5.3
+For a diff between two versions https://github.com/lexik/LexikJWTAuthenticationBundle/compare/v1.0.0...v2.5.4
+
+## [2.5.4](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.5.4) (2018-08-2)
+
+* bug [\#542](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/542) Fix missing implements breaking JWT header alteration ([tucksaun](https://github.com/tucksaun))
 
 ## [2.5.3](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.5.3) (2018-07-6)
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -70,6 +70,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('username')
                     ->cannotBeEmpty()
                 ->end()
+                ->scalarNode('user_id_claim')
+                    ->defaultNull()
+                    ->info('If null, the user ID clam will be have the same name as the one defined by the option "user_identity_field"')
+                ->end()
                 ->append($this->getTokenExtractorsNode())
             ->end();
 

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -60,6 +60,9 @@ class LexikJWTAuthenticationExtension extends Extension
         $container->setParameter('lexik_jwt_authentication.token_ttl', $config['token_ttl']);
         $container->setParameter('lexik_jwt_authentication.clock_skew', $config['clock_skew']);
         $container->setParameter('lexik_jwt_authentication.user_identity_field', $config['user_identity_field']);
+
+        $user_id_claim = $config['user_id_claim'] ? $config['user_id_claim'] : $config['user_identity_field'];
+        $container->setParameter('lexik_jwt_authentication.user_id_claim', $user_id_claim);
         $encoderConfig = $config['encoder'];
 
         if ('lexik_jwt_authentication.encoder.default' === $encoderConfig['service']) {

--- a/Encoder/LcobucciJWTEncoder.php
+++ b/Encoder/LcobucciJWTEncoder.php
@@ -11,7 +11,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\JWSProviderInterfa
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-class LcobucciJWTEncoder implements JWTEncoderInterface
+class LcobucciJWTEncoder implements JWTEncoderInterface, HeaderAwareJWTEncoderInterface
 {
     /**
      * @var JWSProviderInterface

--- a/Resources/config/deprecated.xml
+++ b/Resources/config/deprecated.xml
@@ -9,6 +9,7 @@
         <service id="lexik_jwt_authentication.security.authentication.provider" class="Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Provider\JWTProvider" public="false">
             <argument /> <!-- User Provider -->
             <argument type="service" id="lexik_jwt_authentication.jwt_manager" />
+            <argument>%lexik_jwt_authentication.user_id_claim%</argument>
             <call method="setUserIdentityField">
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>
             </call>

--- a/Resources/config/jwt_manager.xml
+++ b/Resources/config/jwt_manager.xml
@@ -8,6 +8,7 @@
         <service id="lexik_jwt_authentication.jwt_manager" class="Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager" public="true">
             <argument type="service" id="lexik_jwt_authentication.encoder"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument>%lexik_jwt_authentication.user_id_claim%</argument>
             <call method="setUserIdentityField">
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>
             </call>

--- a/Security/Authentication/Provider/JWTProvider.php
+++ b/Security/Authentication/Provider/JWTProvider.php
@@ -45,14 +45,21 @@ class JWTProvider implements AuthenticationProviderInterface
     protected $userIdentityField;
 
     /**
+     * @var string
+     */
+    private $userIdClaim;
+
+    /**
      * @param UserProviderInterface    $userProvider
      * @param JWTManagerInterface      $jwtManager
      * @param EventDispatcherInterface $dispatcher
+     * @param string                   $userIdClaim
      */
     public function __construct(
         UserProviderInterface $userProvider,
         JWTManagerInterface $jwtManager,
-        EventDispatcherInterface $dispatcher
+        EventDispatcherInterface $dispatcher,
+        $userIdClaim
     ) {
         @trigger_error(sprintf('The "%s" class is deprecated since version 2.0 and will be removed in 3.0. See "%s" instead.', __CLASS__, JWTTokenAuthenticator::class), E_USER_DEPRECATED);
 
@@ -60,6 +67,7 @@ class JWTProvider implements AuthenticationProviderInterface
         $this->jwtManager        = $jwtManager;
         $this->dispatcher        = $dispatcher;
         $this->userIdentityField = 'username';
+        $this->userIdClaim       = $userIdClaim;
     }
 
     /**
@@ -97,11 +105,11 @@ class JWTProvider implements AuthenticationProviderInterface
      */
     protected function getUserFromPayload(array $payload)
     {
-        if (!isset($payload[$this->userIdentityField])) {
+        if (!isset($payload[$this->userIdClaim])) {
             throw $this->createAuthenticationException();
         }
 
-        return $this->userProvider->loadUserByUsername($payload[$this->userIdentityField]);
+        return $this->userProvider->loadUserByUsername($payload[$this->userIdClaim]);
     }
 
     /**
@@ -126,6 +134,14 @@ class JWTProvider implements AuthenticationProviderInterface
     public function setUserIdentityField($userIdentityField)
     {
         $this->userIdentityField = $userIdentityField;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserIdClaim()
+    {
+        return $this->userIdClaim;
     }
 
     /**

--- a/Security/Guard/JWTTokenAuthenticator.php
+++ b/Security/Guard/JWTTokenAuthenticator.php
@@ -141,19 +141,20 @@ class JWTTokenAuthenticator extends AbstractGuardAuthenticator
             );
         }
 
-        $payload       = $preAuthToken->getPayload();
-        $identityField = $this->jwtManager->getUserIdentityField();
+        $payload = $preAuthToken->getPayload();
+        $idClaim = $this->jwtManager->getUserIdClaim();
 
-        if (!isset($payload[$identityField])) {
-            throw new InvalidPayloadException($identityField);
+
+        if (!isset($payload[$idClaim])) {
+            throw new InvalidPayloadException($idClaim);
         }
 
-        $identity = $payload[$identityField];
+        $identity = $payload[$idClaim];
 
         try {
             $user = $this->loadUser($userProvider, $payload, $identity);
         } catch (UsernameNotFoundException $e) {
-            throw new UserNotFoundException($identityField, $identity);
+            throw new UserNotFoundException($idClaim, $identity);
         }
 
         $this->preAuthenticationTokenStorage->setToken($preAuthToken);

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -37,14 +37,21 @@ class JWTManager implements JWTManagerInterface, JWTTokenManagerInterface
     protected $userIdentityField;
 
     /**
+     * @var string
+     */
+    protected $userIdClaim;
+
+    /**
      * @param JWTEncoderInterface      $encoder
      * @param EventDispatcherInterface $dispatcher
+     * @param string                   $userIdClaim
      */
-    public function __construct(JWTEncoderInterface $encoder, EventDispatcherInterface $dispatcher)
+    public function __construct(JWTEncoderInterface $encoder, EventDispatcherInterface $dispatcher, $userIdClaim)
     {
         $this->jwtEncoder        = $encoder;
         $this->dispatcher        = $dispatcher;
         $this->userIdentityField = 'username';
+        $this->userIdClaim       = $userIdClaim;
     }
 
     /**
@@ -99,8 +106,8 @@ class JWTManager implements JWTManagerInterface, JWTTokenManagerInterface
      */
     protected function addUserIdentityToPayload(UserInterface $user, array &$payload)
     {
-        $accessor                          = PropertyAccess::createPropertyAccessor();
-        $payload[$this->userIdentityField] = $accessor->getValue($user, $this->userIdentityField);
+        $accessor                    = PropertyAccess::createPropertyAccessor();
+        $payload[$this->userIdClaim] = $accessor->getValue($user, $this->userIdentityField);
     }
 
     /**
@@ -117,5 +124,13 @@ class JWTManager implements JWTManagerInterface, JWTTokenManagerInterface
     public function setUserIdentityField($userIdentityField)
     {
         $this->userIdentityField = $userIdentityField;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserIdClaim()
+    {
+        return $this->userIdClaim;
     }
 }

--- a/Services/JWTTokenManagerInterface.php
+++ b/Services/JWTTokenManagerInterface.php
@@ -40,4 +40,11 @@ interface JWTTokenManagerInterface
      * @return string
      */
     public function getUserIdentityField();
+
+    /**
+     * Returns the claim used as identifier to load an user from a JWT payload.
+     *
+     * @return string
+     */
+    public function getUserIdClaim();
 }

--- a/Tests/Functional/CompleteTokenAuthenticationTest.php
+++ b/Tests/Functional/CompleteTokenAuthenticationTest.php
@@ -88,6 +88,7 @@ class CompleteTokenAuthenticationTest extends TestCase
     {
         static::bootKernel();
         $encoder = static::$kernel->getContainer()->get('lexik_jwt_authentication.encoder');
+        $idClaim = static::$kernel->getContainer()->getParameter('lexik_jwt_authentication.user_id_claim');
 
         $r = new \ReflectionProperty(get_class($encoder), 'jwsProvider');
         $r->setAccessible(true);
@@ -96,7 +97,7 @@ class CompleteTokenAuthenticationTest extends TestCase
             $this->ttl = null;
         }, $jwsProvider, get_class($jwsProvider))->__invoke();
 
-        $token = $encoder->encode(['username' => 'lexik']);
+        $token = $encoder->encode([$idClaim => 'lexik']);
         $this->assertArrayNotHasKey('exp', $encoder->decode($token));
 
         static::$client = static::createAuthenticatedClient($token);

--- a/Tests/Functional/GetTokenTest.php
+++ b/Tests/Functional/GetTokenTest.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional;
 
+use Lcobucci\JWT\Parser;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationSuccessResponse;
@@ -41,6 +42,9 @@ class GetTokenTest extends TestCase
 
         $this->assertArrayHasKey('custom', $payload, 'The payload should contains a "custom" claim.');
         $this->assertSame('dummy', $payload['custom'], 'The "custom" claim should be equal to "dummy".');
+
+        $jws = (new Parser())->parse((string) $body['token']);
+        $this->assertArrayHasKey('foo', $jws->getHeaders(), 'The payload should contains a custom "foo" header.');
     }
 
     public function testGetTokenFromInvalidCredentials()

--- a/Tests/Functional/app/config/config_user_id_claim.yml
+++ b/Tests/Functional/app/config/config_user_id_claim.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: base_config.yml }
+
+lexik_jwt_authentication:
+    secret_key: '%kernel.root_dir%/../config/jwt/private.pem'
+    public_key: '%kernel.root_dir%/../config/jwt/public.pem'
+    pass_phrase: testing
+    user_id_claim: 'sub'

--- a/Tests/Security/Authentication/Provider/JWTProviderTest.php
+++ b/Tests/Security/Authentication/Provider/JWTProviderTest.php
@@ -21,7 +21,7 @@ class JWTProviderTest extends TestCase
      */
     public function testSupports()
     {
-        $provider = new JWTProvider($this->getUserProviderMock(), $this->getJWTManagerMock(), $this->getEventDispatcherMock());
+        $provider = new JWTProvider($this->getUserProviderMock(), $this->getJWTManagerMock(), $this->getEventDispatcherMock(), 'username');
 
         /** @var TokenInterface $usernamePasswordToken */
         $usernamePasswordToken = $this
@@ -60,7 +60,7 @@ class JWTProviderTest extends TestCase
         $jwtManager = $this->getJWTManagerMock();
         $jwtManager->expects($this->any())->method('decode')->will($this->returnValue(false));
 
-        $provider = new JWTProvider($userProvider, $jwtManager, $eventDispatcher);
+        $provider = new JWTProvider($userProvider, $jwtManager, $eventDispatcher, 'username');
         $provider->authenticate($jwtUserToken);
     }
 
@@ -84,7 +84,7 @@ class JWTProviderTest extends TestCase
         $jwtManager = $this->getJWTManagerMock();
         $jwtManager->expects($this->any())->method('decode')->will($this->returnValue(['foo' => 'bar']));
 
-        $provider = new JWTProvider($userProvider, $jwtManager, $eventDispatcher);
+        $provider = new JWTProvider($userProvider, $jwtManager, $eventDispatcher, 'username');
         $provider->authenticate($jwtUserToken);
     }
 
@@ -109,7 +109,7 @@ class JWTProviderTest extends TestCase
         $jwtManager = $this->getJWTManagerMock();
         $jwtManager->expects($this->any())->method('decode')->will($this->returnValue(['username' => 'user']));
 
-        $provider = new JWTProvider($userProvider, $jwtManager, $eventDispatcher);
+        $provider = new JWTProvider($userProvider, $jwtManager, $eventDispatcher, 'username');
         $provider->authenticate($jwtUserToken);
     }
 
@@ -138,7 +138,7 @@ class JWTProviderTest extends TestCase
         $jwtManager = $this->getJWTManagerMock();
         $jwtManager->expects($this->any())->method('decode')->will($this->returnValue(['username' => 'user']));
 
-        $provider = new JWTProvider($userProvider, $jwtManager, $eventDispatcher);
+        $provider = new JWTProvider($userProvider, $jwtManager, $eventDispatcher, 'username');
 
         $this->assertInstanceOf(
             'Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken',
@@ -150,7 +150,7 @@ class JWTProviderTest extends TestCase
         $jwtManager = $this->getJWTManagerMock();
         $jwtManager->expects($this->any())->method('decode')->will($this->returnValue(['uid' => 'user']));
 
-        $provider = new JWTProvider($userProvider, $jwtManager, $eventDispatcher);
+        $provider = new JWTProvider($userProvider, $jwtManager, $eventDispatcher, 'uid');
         $provider->setUserIdentityField('uid');
 
         $this->assertInstanceOf(

--- a/Tests/Services/JWTManagerTest.php
+++ b/Tests/Services/JWTManagerTest.php
@@ -44,7 +44,7 @@ class JWTManagerTest extends TestCase
             ->method('encode')
             ->willReturn('secrettoken');
 
-        $manager = new JWTManager($encoder, $dispatcher);
+        $manager = new JWTManager($encoder, $dispatcher, 'username');
         $this->assertEquals('secrettoken', $manager->create(new User('user', 'password')));
     }
 
@@ -68,7 +68,7 @@ class JWTManagerTest extends TestCase
             ->method('decode')
             ->willReturn(['foo' => 'bar']);
 
-        $manager = new JWTManager($encoder, $dispatcher);
+        $manager = new JWTManager($encoder, $dispatcher, 'username');
         $this->assertEquals(['foo' => 'bar'], $manager->decode($this->getJWTUserTokenMock()));
     }
 
@@ -100,7 +100,7 @@ class JWTManagerTest extends TestCase
             ->method('encode')
             ->willReturn('secrettoken');
 
-        $manager = new JWTManager($encoder, $dispatcher);
+        $manager = new JWTManager($encoder, $dispatcher, 'username');
         $manager->setUserIdentityField('email');
         $this->assertEquals('secrettoken', $manager->create(new CustomUser('user', 'password', 'victuxbb@gmail.com')));
     }

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
             "vendor/bin/simple-phpunit",
             "ENCODER=lcobucci vendor/bin/simple-phpunit",
             "ENCODER=lcobucci ALGORITHM=HS256 vendor/bin/simple-phpunit",
+            "ENCODER=user_id_claim vendor/bin/simple-phpunit",
             "PROVIDER=lexik_jwt vendor/bin/simple-phpunit"
         ]
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,13 +2,11 @@
 
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         colors="always"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
         >
 
@@ -28,5 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
 </phpunit>


### PR DESCRIPTION
This PR modifies the claim used to store the user ID in tokens.
Prior this PR, the claim was the same as the `user_entity_field` option (e.g. `username`).

Now the user ID claim can be customized to the standard claim `sub` (subject) as per the [RFC7519 section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2) or any other value (e.g. `user_id`).

A new configuration option s added: `user_id_claim`. If null, it will have the same value as `user_entity_field`.

This PR also allow a BC with tokens that have already been issued by an application.