### PR TITLE
Example with Symfony > 4.0

### DIFF
--- a/Resources/doc/7-manual-token-creation.md
+++ b/Resources/doc/7-manual-token-creation.md
@@ -4,6 +4,7 @@ Creating JWT tokens programmatically
 It might be useful in many cases to manually create a JWT token for a given user, after confirming user registration by mail for instance.
 To achieve this, use the `lexik_jwt_authentication.jwt_manager` service directly:
 
+Example with SF < Symfony 4.0 
 ```php
 namespace App\Controller;
 
@@ -18,6 +19,25 @@ class ApiController extends Controller
         // ...
 
         $jwtManager = $this->container->get('lexik_jwt_authentication.jwt_manager');
+
+        return new JsonResponse(['token' => $jwtManager->create($user)]);
+    }
+}
+```
+Example with SF > Symfony 4.0 
+```php
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+
+class ApiController extends Controller
+{
+    public function getTokenUser(UserInterface $user, JWTTokenManagerInterface $JWTManager)
+    {
+        // ...
 
         return new JsonResponse(['token' => $jwtManager->create($user)]);
     }


### PR DESCRIPTION
Since SF 4.0, in the controller, it's better to use the interface instead of the service container.
Maybe it can be nice to show the 2 example ?