### PR TITLE
Make exp claim optional.

### DIFF
--- a/Signature/LoadedJWS.php
+++ b/Signature/LoadedJWS.php
@@ -114,7 +114,11 @@ final class LoadedJWS
             return;
         }
 
-        if (!isset($this->payload['exp']) || !is_numeric($this->payload['exp'])) {
+        if (!isset($this->payload['exp'])) {
+            return;
+        }
+
+        if (!is_numeric($this->payload['exp'])) {
             return $this->state = self::INVALID;
         }
 

--- a/Tests/Signature/LoadedJWSTest.php
+++ b/Tests/Signature/LoadedJWSTest.php
@@ -29,7 +29,7 @@ final class LoadedJWSTest extends TestCase
         $jws = new LoadedJWS($payload = [], true);
 
         $this->assertSame($payload, $jws->getPayload());
-        $this->assertFalse($jws->isVerified());
+        $this->assertTrue($jws->isVerified());
         $this->assertFalse($jws->isExpired());
     }
 
@@ -60,6 +60,17 @@ final class LoadedJWSTest extends TestCase
 
         $this->assertFalse($jws->isVerified());
         $this->assertTrue($jws->isExpired());
+    }
+
+    public function testVerifiedWithNoExpClaim()
+    {
+        $payload = $this->goodPayload;
+        unset($payload['exp']);
+
+        $jws = new LoadedJWS($payload, true);
+
+        $this->assertTrue($jws->isVerified());
+        $this->assertFalse($jws->isExpired());
     }
 
     public function testVerifiedWithExpiredPayloadAccountedForByClockSkew()


### PR DESCRIPTION
As per the [RFC](https://tools.ietf.org/html/rfc7519#section-4.1.4), the `exp` claim is optional

> The "exp" (expiration time) claim identifies the expiration time on
   or after which the JWT MUST NOT be accepted for processing.  The
   processing of the "exp" claim requires that the current date/time
   MUST be before the expiration date/time listed in the "exp" claim.
   Implementers MAY provide for some small leeway, usually no more than
   a few minutes, to account for clock skew.  Its value MUST be a number
   containing a NumericDate value.  Use of this claim is OPTIONAL.

But, there is currently no way to achieve this, as the `LoadedJWS` class expects the key `exp` to be set. 

This Pull Request allows to unset the `exp` claim, and does not enforce the `exp` key to be present.

Fixes #521 