### PR TITLE
Allow JWTTokenAuthenticator to be extended

### DIFF
--- a/Security/Guard/JWTTokenAuthenticator.php
+++ b/Security/Guard/JWTTokenAuthenticator.php
@@ -43,22 +43,22 @@ class JWTTokenAuthenticator extends AbstractGuardAuthenticator
     /**
      * @var JWTTokenManagerInterface
      */
-    private $jwtManager;
+    protected $jwtManager;
 
     /**
      * @var EventDispatcherInterface
      */
-    private $dispatcher;
+    protected $dispatcher;
 
     /**
      * @var TokenExtractorInterface
      */
-    private $tokenExtractor;
+    protected $tokenExtractor;
 
     /**
      * @var TokenStorageInterface
      */
-    private $preAuthenticationTokenStorage;
+    protected $preAuthenticationTokenStorage;
 
     /**
      * @param JWTTokenManagerInterface $jwtManager


### PR DESCRIPTION
Changed all `private` into `protected` members to make them usable inside extending classes