### PR TITLE
allow to pass payload to JWTManager directly

### DIFF
--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -57,9 +57,10 @@ class JWTManager implements JWTManagerInterface, JWTTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function create(UserInterface $user)
+    public function create(UserInterface $user, $payload = [])
     {
-        $payload = ['roles' => $user->getRoles()];
+        $payload = array_merge(['roles' => $user->getRoles()], $payload);
+
         $this->addUserIdentityToPayload($user, $payload);
 
         $jwtCreatedEvent = new JWTCreatedEvent($payload, $user);

--- a/Services/JWTManagerInterface.php
+++ b/Services/JWTManagerInterface.php
@@ -16,10 +16,11 @@ interface JWTManagerInterface
 {
     /**
      * @param UserInterface $user
+     * @param array $payload
      *
      * @return string The JWT token
      */
-    public function create(UserInterface $user);
+    public function create(UserInterface $user, $payload = []);
 
     /**
      * @param TokenInterface $token


### PR DESCRIPTION
hi, using event to add payload to JWT is not good enough, because this design forces us to save the payload in another place.  it is best to allow to pass payload to JWTManager directly I think, we need to add a field into the payload  which is not depended on the user object, this way can let us reuse JWTManager easier.