### PR TITLE
Update the openssl commands to not use "genrsa" and "rsa"

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -39,12 +39,12 @@ return [
 ];
 ```
 
-#### Generate the SSH keys :
+#### Generate the SSH keys:
 
 ``` bash
-$ mkdir -p config/jwt # For Symfony3+, no need of the -p option
-$ openssl genrsa -out config/jwt/private.pem -aes256 4096
-$ openssl rsa -pubout -in config/jwt/private.pem -out config/jwt/public.pem
+$ mkdir -p config/jwt
+$ openssl genpkey -out config/jwt/private.pem -aes256 -algorithm rsa -pkeyopt rsa_keygen_bits:4096
+$ openssl pkey -in config/jwt/private.pem -out config/jwt/public.pem -pubout
 ```
 
 Configuration


### PR DESCRIPTION
`genrsa` is superseded by `genpkey`: https://www.openssl.org/docs/manmaster/man1/openssl.html

And `pkey` is the generic "public and private key management". No need to use the algorithm-specific `rsa` command.