### PR TITLE
Use late static binding on JWTUser

### DIFF
--- a/Security/User/JWTUser.php
+++ b/Security/User/JWTUser.php
@@ -27,10 +27,10 @@ class JWTUser implements JWTUserInterface
     public static function createFromPayload($username, array $payload)
     {
         if (isset($payload['roles'])) {
-            return new self($username, (array) $payload['roles']);
+            return new static($username, (array) $payload['roles']);
         }
 
-        return new self($username);
+        return new static($username);
     }
 
     /**

--- a/Tests/Functional/CompleteTokenAuthenticationTest.php
+++ b/Tests/Functional/CompleteTokenAuthenticationTest.php
@@ -2,7 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional;
 
-use Lexik\Bundle\JWTAuthenticationBundle\Security\User\JWTUser;
+use Lexik\Bundle\JWTAuthenticationBundle\Tests\Stubs\JWTUser;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\User\User;
 


### PR DESCRIPTION
use late static binding on `JWTUser` so I as a developer can extend this class (createFromPayload can now return instance of class extending this class)

https://www.php.net/manual/en/language.oop5.late-static-bindings.php