### PR TITLE
chore/implement-against-key-loader-interface

### DIFF
--- a/Resources/config/token_authenticator.xml
+++ b/Resources/config/token_authenticator.xml
@@ -11,6 +11,9 @@
             <argument type="service" id="lexik_jwt_authentication.jwt_manager"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="lexik_jwt_authentication.extractor.chain_extractor"/>
+            <argument type="service">
+                <service class="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage" />
+            </argument>
         </service>
     </services>
 </container>

--- a/Security/Authentication/Token/PreAuthenticationJWTUserToken.php
+++ b/Security/Authentication/Token/PreAuthenticationJWTUserToken.php
@@ -9,7 +9,7 @@ use Symfony\Component\Security\Guard\Token\PreAuthenticationGuardToken;
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-final class PreAuthenticationJWTUserToken extends PreAuthenticationGuardToken
+final class PreAuthenticationJWTUserToken extends PreAuthenticationGuardToken implements PreAuthenticationJWTUserTokenInterface
 {
     /**
      * @var string

--- a/Security/Authentication/Token/PreAuthenticationJWTUserTokenInterface.php
+++ b/Security/Authentication/Token/PreAuthenticationJWTUserTokenInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token;
+
+use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
+
+interface PreAuthenticationJWTUserTokenInterface extends GuardTokenInterface
+{
+
+    /**
+     * @param array $payload
+     * @return void
+     */
+    public function setPayload(array $payload);
+
+    /**
+     * @return mixed
+     */
+    public function getPayload();
+}

--- a/Security/Guard/JWTTokenAuthenticator.php
+++ b/Security/Guard/JWTTokenAuthenticator.php
@@ -16,6 +16,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Exception\UserNotFoundException;
 use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\PreAuthenticationJWTUserToken;
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\PreAuthenticationJWTUserTokenInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\User\PayloadAwareUserProviderInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
@@ -66,16 +67,18 @@ class JWTTokenAuthenticator extends AbstractGuardAuthenticator
      * @param JWTTokenManagerInterface $jwtManager
      * @param EventDispatcherInterface $dispatcher
      * @param TokenExtractorInterface  $tokenExtractor
+     * @param TokenStorageInterface    $preAuthenticationTokenStorage
      */
     public function __construct(
         JWTTokenManagerInterface $jwtManager,
         EventDispatcherInterface $dispatcher,
-        TokenExtractorInterface $tokenExtractor
+        TokenExtractorInterface $tokenExtractor,
+        TokenStorageInterface $preAuthenticationTokenStorage
     ) {
         $this->jwtManager                    = $jwtManager;
         $this->dispatcher                    = $dispatcher;
         $this->tokenExtractor                = $tokenExtractor;
-        $this->preAuthenticationTokenStorage = new TokenStorage();
+        $this->preAuthenticationTokenStorage = $preAuthenticationTokenStorage;
     }
 
     public function supports(Request $request)
@@ -88,7 +91,7 @@ class JWTTokenAuthenticator extends AbstractGuardAuthenticator
      *
      * {@inheritdoc}
      *
-     * @return PreAuthenticationJWTUserToken
+     * @return PreAuthenticationJWTUserTokenInterface
      *
      * @throws InvalidTokenException If an error occur while decoding the token
      * @throws ExpiredTokenException If the request token is expired
@@ -129,7 +132,7 @@ class JWTTokenAuthenticator extends AbstractGuardAuthenticator
      *
      * {@inheritdoc}
      *
-     * @param PreAuthenticationJWTUserToken Implementation of the (Security) TokenInterface
+     * @param PreAuthenticationJWTUserTokenInterface Implementation of the (Security) TokenInterface
      *
      * @throws \InvalidArgumentException If preAuthToken is not of the good type
      * @throws InvalidPayloadException   If the user identity field is not a key of the payload
@@ -137,9 +140,9 @@ class JWTTokenAuthenticator extends AbstractGuardAuthenticator
      */
     public function getUser($preAuthToken, UserProviderInterface $userProvider)
     {
-        if (!$preAuthToken instanceof PreAuthenticationJWTUserToken) {
+        if (!$preAuthToken instanceof PreAuthenticationJWTUserTokenInterface) {
             throw new \InvalidArgumentException(
-                sprintf('The first argument of the "%s()" method must be an instance of "%s".', __METHOD__, PreAuthenticationJWTUserToken::class)
+                sprintf('The first argument of the "%s()" method must be an instance of "%s".', __METHOD__, PreAuthenticationJWTUserTokenInterface::class)
             );
         }
 

--- a/Services/JWSProvider/LcobucciJWSProvider.php
+++ b/Services/JWSProvider/LcobucciJWSProvider.php
@@ -9,6 +9,7 @@ use Lcobucci\JWT\Signer\Hmac;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\ValidationData;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\KeyLoaderInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\RawKeyLoader;
 use Lexik\Bundle\JWTAuthenticationBundle\Signature\CreatedJWS;
 use Lexik\Bundle\JWTAuthenticationBundle\Signature\LoadedJWS;
@@ -21,7 +22,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Signature\LoadedJWS;
 class LcobucciJWSProvider implements JWSProviderInterface
 {
     /**
-     * @var RawKeyLoader
+     * @var KeyLoaderInterface
      */
     private $keyLoader;
 
@@ -41,15 +42,15 @@ class LcobucciJWSProvider implements JWSProviderInterface
     private $clockSkew;
 
     /**
-     * @param RawKeyLoader $keyLoader
-     * @param string       $cryptoEngine
-     * @param string       $signatureAlgorithm
-     * @param int|null     $ttl
-     * @param int          $clockSkew
+     * @param KeyLoaderInterface $keyLoader
+     * @param string             $cryptoEngine
+     * @param string             $signatureAlgorithm
+     * @param int|null           $ttl
+     * @param int                $clockSkew
      *
      * @throws \InvalidArgumentException If the given crypto engine is not supported
      */
-    public function __construct(RawKeyLoader $keyLoader, $cryptoEngine, $signatureAlgorithm, $ttl, $clockSkew)
+    public function __construct(KeyLoaderInterface $keyLoader, $cryptoEngine, $signatureAlgorithm, $ttl, $clockSkew)
     {
         if ('openssl' !== $cryptoEngine) {
             throw new \InvalidArgumentException(sprintf('The %s provider supports only "openssl" as crypto engine.', __CLASS__));

--- a/Tests/Security/Guard/JWTTokenAuthenticatorTest.php
+++ b/Tests/Security/Guard/JWTTokenAuthenticatorTest.php
@@ -21,6 +21,8 @@ use Lexik\Bundle\JWTAuthenticationBundle\Tests\Stubs\User as AdvancedUserStub;
 use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
@@ -39,7 +41,8 @@ class JWTTokenAuthenticatorTest extends TestCase
         $authenticator = new JWTTokenAuthenticator(
             $jwtManager,
             $this->getEventDispatcherMock(),
-            $this->getTokenExtractorMock('token')
+            $this->getTokenExtractorMock('token'),
+            $this->getTokenStorageMock()
         );
 
         $this->assertInstanceOf(PreAuthenticationJWTUserToken::class, $authenticator->getCredentials($this->getRequestMock()));
@@ -51,7 +54,8 @@ class JWTTokenAuthenticatorTest extends TestCase
             (new JWTTokenAuthenticator(
                 $this->getJWTManagerMock(),
                 $this->getEventDispatcherMock(),
-                $this->getTokenExtractorMock('token')
+                $this->getTokenExtractorMock('token'),
+                $this->getTokenStorageMock()
             ))->getCredentials($this->getRequestMock());
 
             $this->fail(sprintf('Expected exception of type "%s" to be thrown.', InvalidTokenException::class));
@@ -73,7 +77,8 @@ class JWTTokenAuthenticatorTest extends TestCase
             (new JWTTokenAuthenticator(
                 $jwtManager,
                 $this->getEventDispatcherMock(),
-                $this->getTokenExtractorMock('token')
+                $this->getTokenExtractorMock('token'),
+                $this->getTokenStorageMock()
             ))->getCredentials($this->getRequestMock());
 
             $this->fail(sprintf('Expected exception of type "%s" to be thrown.', ExpiredTokenException::class));
@@ -87,7 +92,8 @@ class JWTTokenAuthenticatorTest extends TestCase
         $authenticator = new JWTTokenAuthenticator(
             $this->getJWTManagerMock(),
             $this->getEventDispatcherMock(),
-            $this->getTokenExtractorMock(false)
+            $this->getTokenExtractorMock(false),
+            $this->getTokenStorageMock()
         );
 
         $this->assertNull($authenticator->getCredentials($this->getRequestMock()));
@@ -115,7 +121,8 @@ class JWTTokenAuthenticatorTest extends TestCase
         $authenticator = new JWTTokenAuthenticator(
             $this->getJWTManagerMock(null, $userIdClaim),
             $this->getEventDispatcherMock(),
-            $this->getTokenExtractorMock()
+            $this->getTokenExtractorMock(),
+            $this->getTokenStorageMock()
         );
 
         $this->assertSame($userStub, $authenticator->getUser($decodedToken, $userProvider));
@@ -130,7 +137,8 @@ class JWTTokenAuthenticatorTest extends TestCase
             (new JWTTokenAuthenticator(
                 $this->getJWTManagerMock(null, 'username'),
                 $this->getEventDispatcherMock(),
-                $this->getTokenExtractorMock()
+                $this->getTokenExtractorMock(),
+                $this->getTokenStorageMock()
             ))->getUser($decodedToken, $this->getUserProviderMock());
 
             $this->fail(sprintf('Expected exception of type "%s" to be thrown.', InvalidPayloadException::class));
@@ -146,7 +154,8 @@ class JWTTokenAuthenticatorTest extends TestCase
         (new JWTTokenAuthenticator(
             $this->getJWTManagerMock(),
             $this->getEventDispatcherMock(),
-            $this->getTokenExtractorMock()
+            $this->getTokenExtractorMock(),
+            $this->getTokenStorageMock()
         ))->getUser(new \stdClass(), $this->getUserProviderMock());
     }
 
@@ -169,7 +178,8 @@ class JWTTokenAuthenticatorTest extends TestCase
             (new JWTTokenAuthenticator(
                 $this->getJWTManagerMock(null, 'username'),
                 $this->getEventDispatcherMock(),
-                $this->getTokenExtractorMock()
+                $this->getTokenExtractorMock(),
+                $this->getTokenStorageMock()
             ))->getUser($decodedToken, $userProvider);
 
             $this->fail(sprintf('Expected exception of type "%s" to be thrown.', UserNotFoundException::class));
@@ -190,13 +200,19 @@ class JWTTokenAuthenticatorTest extends TestCase
 
         $jwtUserToken = new JWTUserToken($userRoles, $userStub, $rawToken, 'lexik');
 
+        $tokenStorage = $this->getTokenStorageMock();
+
+        $tokenStorage->expects(self::exactly(2))->method('setToken')->withConsecutive([$decodedToken], [null]);
+        $tokenStorage->expects(self::once())->method('getToken')->willReturn($decodedToken);
+
         $dispatcher = $this->getEventDispatcherMock();
         $this->expectEvent(Events::JWT_AUTHENTICATED, new JWTAuthenticatedEvent($payload, $jwtUserToken), $dispatcher);
 
         $authenticator = new JWTTokenAuthenticator(
             $this->getJWTManagerMock(null, 'sub'),
             $dispatcher,
-            $this->getTokenExtractorMock()
+            $this->getTokenExtractorMock(),
+            $tokenStorage
         );
 
         $userProvider = $this->getUserProviderMock();
@@ -218,10 +234,16 @@ class JWTTokenAuthenticatorTest extends TestCase
 
         $userStub = new AdvancedUserStub('lexik', 'test');
 
+        $tokenStorage = $this->getTokenStorageMock();
+
+        $tokenStorage->expects(self::never())->method('setToken');
+        $tokenStorage->expects(self::once())->method('getToken')->willReturn(null);
+
         (new JWTTokenAuthenticator(
            $this->getJWTManagerMock(),
            $this->getEventDispatcherMock(),
-           $this->getTokenExtractorMock()
+           $this->getTokenExtractorMock(),
+           $tokenStorage
        ))->createAuthenticatedToken($userStub, 'lexik');
     }
 
@@ -236,7 +258,8 @@ class JWTTokenAuthenticatorTest extends TestCase
         $authenticator = new JWTTokenAuthenticator(
             $this->getJWTManagerMock(),
             $dispatcher,
-            $this->getTokenExtractorMock()
+            $this->getTokenExtractorMock(),
+            $this->getTokenStorageMock()
         );
 
         $response = $authenticator->onAuthenticationFailure($this->getRequestMock(), $authException);
@@ -256,7 +279,8 @@ class JWTTokenAuthenticatorTest extends TestCase
         $authenticator = new JWTTokenAuthenticator(
             $this->getJWTManagerMock(),
             $dispatcher,
-            $this->getTokenExtractorMock()
+            $this->getTokenExtractorMock(),
+            $this->getTokenStorageMock()
         );
 
         $response = $authenticator->start($this->getRequestMock());
@@ -273,7 +297,8 @@ class JWTTokenAuthenticatorTest extends TestCase
             (new JWTTokenAuthenticator(
                 $this->getJWTManagerMock(),
                 $this->getEventDispatcherMock(),
-                $this->getTokenExtractorMock()
+                $this->getTokenExtractorMock(),
+                $this->getTokenStorageMock()
             ))->checkCredentials(null, $user)
         );
     }
@@ -284,7 +309,8 @@ class JWTTokenAuthenticatorTest extends TestCase
             (new JWTTokenAuthenticator(
                 $this->getJWTManagerMock(),
                 $this->getEventDispatcherMock(),
-                $this->getTokenExtractorMock()
+                $this->getTokenExtractorMock(),
+                $this->getTokenStorageMock()
             ))->supportsRememberMe()
         );
     }
@@ -346,6 +372,16 @@ class JWTTokenAuthenticatorTest extends TestCase
         return $this->getMockBuilder(UserProviderInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|TokenStorageInterface
+     */
+    private function getTokenStorageMock()
+    {
+        return $this->getMockBuilder(TokenStorageInterface::class)
+            ->setMethods(['getToken', 'setToken'])
+            ->getMockForAbstractClass();
     }
 
     private function expectEvent($eventName, $event, $dispatcher)


### PR DESCRIPTION
`LcobucciJWSProvider` currently takes an instance of `RawKeyLoader` as an argument in the constructor instead of an instance of the interface `KeyLoaderInterface` which gets implemented by the `RawKeyLoader` class.