### PR TITLE
chore/inject-token-storage

### DIFF
--- a/Resources/config/token_authenticator.xml
+++ b/Resources/config/token_authenticator.xml
@@ -11,6 +11,9 @@
             <argument type="service" id="lexik_jwt_authentication.jwt_manager"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="lexik_jwt_authentication.extractor.chain_extractor"/>
+            <argument type="service">
+                <service class="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage" />
+            </argument>
         </service>
     </services>
 </container>

--- a/Security/Guard/JWTTokenAuthenticator.php
+++ b/Security/Guard/JWTTokenAuthenticator.php
@@ -65,16 +65,18 @@ class JWTTokenAuthenticator extends AbstractGuardAuthenticator
      * @param JWTTokenManagerInterface $jwtManager
      * @param EventDispatcherInterface $dispatcher
      * @param TokenExtractorInterface  $tokenExtractor
+     * @param TokenStorageInterface    $preAuthenticationTokenStorage
      */
     public function __construct(
         JWTTokenManagerInterface $jwtManager,
         EventDispatcherInterface $dispatcher,
-        TokenExtractorInterface $tokenExtractor
+        TokenExtractorInterface $tokenExtractor,
+        TokenStorageInterface $preAuthenticationTokenStorage
     ) {
         $this->jwtManager                    = $jwtManager;
         $this->dispatcher                    = $dispatcher;
         $this->tokenExtractor                = $tokenExtractor;
-        $this->preAuthenticationTokenStorage = new TokenStorage();
+        $this->preAuthenticationTokenStorage = $preAuthenticationTokenStorage;
     }
 
     public function supports(Request $request)


### PR DESCRIPTION
There is currently a `TokenStorage` instantiated in the `JWTTokenAuthenticator` class. Instead of this it would be preferable to implement against the `TokenStorageInterface` and inject an instance which also makes it better testable.

Tests for PHP 5.5 don't work anymore in general:

```
$ phpenv global 5.5 2>/dev/null

5.5 is not pre-installed; installing

Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/php/binaries/ubuntu/16.04/x86_64/php-5.5.tar.bz2

0.12s$ curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /

bzip2: (stdin) is not a bzip2 file.

tar: Child returned status 2

tar: Error is not recoverable: exiting now

0.02s$ phpenv global 5.5

rbenv: version `5.5' not installed

The command "phpenv global 5.5" failed and exited with 1 during .

Your build has been stopped.
```