### PR TITLE
index.md: strip leading `$` from bash commands

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -42,9 +42,9 @@ return [
 #### Generate the SSH keys:
 
 ``` bash
-$ mkdir -p config/jwt
-$ openssl genpkey -out config/jwt/private.pem -aes256 -algorithm rsa -pkeyopt rsa_keygen_bits:4096
-$ openssl pkey -in config/jwt/private.pem -out config/jwt/public.pem -pubout
+mkdir -p config/jwt
+openssl genpkey -out config/jwt/private.pem -aes256 -algorithm rsa -pkeyopt rsa_keygen_bits:4096
+openssl pkey -in config/jwt/private.pem -out config/jwt/public.pem -pubout
 ```
 
 Configuration


### PR DESCRIPTION
It allows us to easily copy-paste them without having to manually remove the leading `$`.

Note: this is open for discussion. I'm aware that blindly copy-pasting commands from the internet without understanding them can be dangerous