### PR TITLE
Authentication Exception Message from its key, Explicit Travis build env, and .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 vendor
 composer.lock
 composer.phar
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 matrix:
   fast_finish: true
   include:

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -38,7 +38,7 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
     {
         $event = new AuthenticationFailureEvent(
             $exception,
-            new JWTAuthenticationFailureResponse($exception->getMessage())
+            new JWTAuthenticationFailureResponse($exception->getMessageKey())
         );
 
         if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {

--- a/Tests/Functional/GetTokenTest.php
+++ b/Tests/Functional/GetTokenTest.php
@@ -62,7 +62,7 @@ class GetTokenTest extends TestCase
         $this->assertArrayHasKey('message', $body, 'The response should have a "message" key containing the failure reason.');
         $this->assertArrayHasKey('code', $body, 'The response should have a "code" key containing the response status code.');
 
-        $this->assertSame('Bad credentials.', $body['message']);
+        $this->assertSame('Invalid credentials.', $body['message']);
         $this->assertSame(401, $body['code']);
     }
 }

--- a/Tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
+++ b/Tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
@@ -32,7 +32,7 @@ class AuthenticationFailureHandlerTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
         $this->assertEquals(401, $response->getStatusCode());
         $this->assertEquals(401, $content['code']);
-        $this->assertEquals($authenticationException->getMessage(), $content['message']);
+        $this->assertEquals($authenticationException->getMessageKey(), $content['message']);
     }
 
     /**
@@ -47,7 +47,7 @@ class AuthenticationFailureHandlerTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return AuthenticationException
      */
     protected function getAuthenticationException()
     {


### PR DESCRIPTION
There are 3 issues addressed here. I would have used different PR for each issue but there was problem with travis build env that wouldn't have produced accurate results if not combined.

1. Updated Travis build env as you can see php 5.5 build are failing. Travis has recently [changed it default build env to Xenial](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) and I have explicitly specified it to be "Trusty". 

2. Addresses [the concern](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/650#issuecomment-505123009) of Authentication Exception message to be retrieved by getMessage. I have changed it to getMessageKey method to meet symfony convention, help translation and prevent possible leak of sensitive info to end user. Also addresses #684

3. Adds .idea to .gitignore
Most of use PHPStorm and it creates .idea folder that is an issue while working. It should be in .gitignore to prevent its accidental addition to repository. It also helps to work on this library quickly as you don't have to deal with .idea first. 
