### PR TITLE
Test against symfony 5.1 and fix deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,16 @@ dist: trusty
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
-      env: SYMFONY_VERSION=3.4.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.4.* SYMFONY_PHPUNIT_VERSION=5.7
     - php: 7.3
       env: SYMFONY_VERSION=4.3.*
     - php: 7.3
       env: SYMFONY_VERSION=4.4.*
     - php: 7.3
       env: SYMFONY_VERSION=5.0.*
+    - php: 7.3
+      env: SYMFONY_VERSION=5.1.*
 
 cache:
   directories:

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -24,11 +25,11 @@ class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('private_key_path')
-                    ->setDeprecated('The "%path%.%node%" configuration key is deprecated since version 2.5. Use "%path%.secret_key" instead.')
+                    ->setDeprecated(...$this->getDeprecationParameters('The "%path%.%node%" configuration key is deprecated since version 2.5. Use "%path%.secret_key" instead.', '2.5'))
                     ->defaultNull()
                 ->end()
                 ->scalarNode('public_key_path')
-                    ->setDeprecated('The "%path%.%node%" configuration key is deprecated since version 2.5. Use "%path%.public_key" instead.')
+                    ->setDeprecated(...$this->getDeprecationParameters('The "%path%.%node%" configuration key is deprecated since version 2.5. Use "%path%.public_key" instead.', '2.5'))
                     ->defaultNull()
                 ->end()
                 ->scalarNode('public_key')
@@ -62,7 +63,7 @@ class Configuration implements ConfigurationInterface
                         ->enumNode('crypto_engine')
                             ->values(['openssl', 'phpseclib'])
                             ->defaultValue('openssl')
-                            ->setDeprecated('The "%path%.%node%" configuration key is deprecated since version 2.5, built-in encoders support OpenSSL only')
+                            ->setDeprecated(...$this->getDeprecationParameters('The "%path%.%node%" configuration key is deprecated since version 2.5, built-in encoders support OpenSSL only', '2.5'))
                         ->end()
                     ->end()
                 ->end()
@@ -121,5 +122,22 @@ class Configuration implements ConfigurationInterface
         ;
 
         return $node;
+    }
+
+    /**
+     * Returns the correct deprecation parameters for setDeprecated.
+     *
+     * @param string $message
+     * @param string $version
+     *
+     * @return string[]
+     */
+    private function getDeprecationParameters($message, $version)
+    {
+        if (method_exists(BaseNode::class, 'getDeprecation')) {
+            return ['lexik/jwt-authentication-bundle', $version, $message];
+        }
+
+        return [$message];
     }
 }

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -33,7 +33,11 @@ class LexikJWTAuthenticationExtension extends Extension
             $loader->load('console.xml');
         }
 
-        $loader->load('deprecated.xml');
+        if (method_exists(Alias::class, 'getDeprecation')) {
+            $loader->load('deprecated_51.xml');
+        } else {
+            $loader->load('deprecated.xml');
+        }
         $loader->load('jwt_manager.xml');
         $loader->load('key_loader.xml');
         $loader->load('namshi.xml');

--- a/DependencyInjection/Security/Factory/JWTFactory.php
+++ b/DependencyInjection/Security/Factory/JWTFactory.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
+use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -98,8 +99,13 @@ class JWTFactory implements SecurityFactoryInterface
      */
     public function addConfiguration(NodeDefinition $node)
     {
+        $deprecationArgs = [];
+        if (method_exists(BaseNode::class, 'getDeprecation')) {
+            $deprecationArgs = ['lexik/jwt-authentication-bundle', '2.7'];
+        }
+
         if (method_exists($node, 'setDeprecated')) {
-            $node->setDeprecated();
+            $node->setDeprecated(...$deprecationArgs);
         }
 
         $node

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ LexikJWTAuthenticationBundle
 
 This bundle provides JWT (Json Web Token) authentication for your Symfony API.
 
-It is compatible and tested with PHP 5.5, 7.2, 7.3, on Symfony 3.4 and 4.2.
+It is compatible and tested with PHP 5.6, 7.2, 7.3, on Symfony 3.4 and 4.2.
 
 Documentation
 -------------

--- a/Resources/config/deprecated_51.xml
+++ b/Resources/config/deprecated_51.xml
@@ -5,6 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <!-- Updated deprecation element for Symfony 5.1+ -->
         <!-- Deprecated -->
         <service id="lexik_jwt_authentication.security.authentication.provider" class="Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Provider\JWTProvider" public="false">
             <argument /> <!-- User Provider -->
@@ -14,7 +15,7 @@
             <call method="setUserIdentityField">
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>
             </call>
-            <deprecated>The "%service_id%" service is deprecated since LexikJWTAuthenticationBundle version 2.0 and will be removed in 3.0</deprecated>
+            <deprecated package="lexik/jwt-authentication-bundle" version="2.0">The "%service_id%" service is deprecated since LexikJWTAuthenticationBundle version 2.0 and will be removed in 3.0</deprecated>
         </service>
         <service id="lexik_jwt_authentication.security.authentication.listener" class="Lexik\Bundle\JWTAuthenticationBundle\Security\Firewall\JWTListener" public="false">
             <argument type="service" id="security.token_storage"/>
@@ -23,19 +24,19 @@
             <call method="setDispatcher">
                 <argument type="service" id="event_dispatcher"/>
             </call>
-            <deprecated>The "%service_id%" service is deprecated since LexikJWTAuthenticationBundle version 2.0 and will be removed in 3.0</deprecated>
+            <deprecated package="lexik/jwt-authentication-bundle" version="2.0">The "%service_id%" service is deprecated since LexikJWTAuthenticationBundle version 2.0 and will be removed in 3.0</deprecated>
         </service>
         <service id="lexik_jwt_authentication.security.authentication.entry_point" class="Lexik\Bundle\JWTAuthenticationBundle\Security\Http\EntryPoint\JWTEntryPoint" public="false">
-            <deprecated>The "%service_id%" service is deprecated since LexikJWTAuthenticationBundle version 2.0 and will be removed in 3.0</deprecated>
+            <deprecated package="lexik/jwt-authentication-bundle" version="2.0">The "%service_id%" service is deprecated since LexikJWTAuthenticationBundle version 2.0 and will be removed in 3.0</deprecated>
         </service>
         <service id="Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenInterface" alias="lexik_jwt_authentication.jwt_manager" />
 
         <service id="lexik_jwt_authentication.key_loader.openssl" class="Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\OpenSSLKeyLoader" parent="lexik_jwt_authentication.key_loader.abstract">
-            <deprecated>The "%service_id%" service is deprecated since version 2.5 and will be removed in 3.0. Use lexik_jwt_authentication.key_loader.raw instead.</deprecated>
+            <deprecated package="lexik/jwt-authentication-bundle" version="2.5">The "%service_id%" service is deprecated since version 2.5 and will be removed in 3.0. Use lexik_jwt_authentication.key_loader.raw instead.</deprecated>
         </service>
 
         <service id="lexik_jwt_authentication.jws_provider.default" class="Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\DefaultJWSProvider" public="false">
-            <deprecated>The "%service_id%" is deprecated since version 2.5 and will be removed in 5.0, use "lexik_jwt_authentication.jws_provider.lcobucci" instead.</deprecated>
+            <deprecated package="lexik/jwt-authentication-bundle" version="2.5">The "%service_id%" is deprecated since version 2.5 and will be removed in 5.0, use "lexik_jwt_authentication.jws_provider.lcobucci" instead.</deprecated>
             <argument type="service" id="lexik_jwt_authentication.key_loader"/>
             <argument>%lexik_jwt_authentication.encoder.crypto_engine%</argument>
             <argument>%lexik_jwt_authentication.encoder.signature_algorithm%</argument>

--- a/Resources/config/key_loader.xml
+++ b/Resources/config/key_loader.xml
@@ -10,9 +10,6 @@
             <argument/> <!-- public key -->
             <argument>%lexik_jwt_authentication.pass_phrase%</argument>
         </service>
-        <service id="lexik_jwt_authentication.key_loader.openssl" class="Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\OpenSSLKeyLoader" parent="lexik_jwt_authentication.key_loader.abstract">
-            <deprecated>The "%service_id%" service is deprecated since version 2.5 and will be removed in 3.0. Use lexik_jwt_authentication.key_loader.raw instead.</deprecated>
-        </service>
         <service id="lexik_jwt_authentication.key_loader.raw" class="Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\RawKeyLoader" parent="lexik_jwt_authentication.key_loader.abstract"/>
     </services>
 </container>

--- a/Resources/config/namshi.xml
+++ b/Resources/config/namshi.xml
@@ -10,13 +10,5 @@
         </service>
 
         <service id="Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\JWSProviderInterface" alias="lexik_jwt_authentication.jws_provider.default" />
-        <service id="lexik_jwt_authentication.jws_provider.default" class="Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\DefaultJWSProvider" public="false">
-            <deprecated>The "%service_id%" is deprecated since version 2.5 and will be removed in 5.0, use "lexik_jwt_authentication.jws_provider.lcobucci" instead.</deprecated>
-            <argument type="service" id="lexik_jwt_authentication.key_loader"/>
-            <argument>%lexik_jwt_authentication.encoder.crypto_engine%</argument>
-            <argument>%lexik_jwt_authentication.encoder.signature_algorithm%</argument>
-            <argument>%lexik_jwt_authentication.token_ttl%</argument>
-            <argument>%lexik_jwt_authentication.clock_skew%</argument>
-        </service>
     </services>
 </container>

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional;
 
 use Psr\Log\NullLogger;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
@@ -70,6 +71,11 @@ class AppKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
+        if (\method_exists(TreeBuilder::class, 'getRootNode')) {
+            // Symfony 4.2+
+            $loader->load(__DIR__.'/config/config_router_utf8.yml');
+        }
+        
         if ($this->testCase && file_exists(__DIR__.'/config/'.$this->testCase.'/config.yml')) {
             $loader->load(__DIR__.'/config/'.$this->testCase.'/config.yml');
 

--- a/Tests/Functional/app/config/config_router_utf8.yml
+++ b/Tests/Functional/app/config/config_router_utf8.yml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        utf8: true

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     ],
     "require": {
-        "php": "^5.5|^7.0",
+        "php": "^5.6|^7.0",
         "ext-openssl": "*",
         "lcobucci/jwt": "^3.2",
         "namshi/jose": "^7.2",


### PR DESCRIPTION
In order to fix this deprecation I had to bump the minimum supported php version to 5.6. 
I don't know what the policy is on supporting php versions, but php 5.5 is EOL for a long time now so I guess this is ok to do?

This pr now fixes also other symfony 5.1 deprecations