### PR TITLE
Added the possibility to choose if the cookie is "secure" or not

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -93,6 +93,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('path')->defaultValue('/')->cannotBeEmpty()->end()
                             ->scalarNode('domain')->defaultNull()->end()
+                            ->scalarNode('secure')->defaultTrue()->end()
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -110,7 +110,8 @@ class LexikJWTAuthenticationExtension extends Extension
                     ->replaceArgument(1, $attributes['lifetime'] ?: ($config['token_ttl'] ?: 0))
                     ->replaceArgument(2, $attributes['samesite'])
                     ->replaceArgument(3, $attributes['path'])
-                    ->replaceArgument(4, $attributes['domain']);
+                    ->replaceArgument(4, $attributes['domain'])
+                    ->replaceArgument(5, $attributes['secure']);
                 $cookieProviders[] = new Reference($id);
             }
 

--- a/Resources/config/cookie.xml
+++ b/Resources/config/cookie.xml
@@ -11,6 +11,7 @@
             <argument/> <!-- Default samesite -->
             <argument/> <!-- Default path -->
             <argument>null</argument> <!-- Default domain -->
+            <argument/> <!-- Default secure -->
         </service>
     </services>
 </container>

--- a/Resources/doc/1-configuration-reference.md
+++ b/Resources/doc/1-configuration-reference.md
@@ -101,6 +101,7 @@ set_cookies:
 #      samesite: lax
 #      path: /
 #      domain: null (null means automatically set by symfony)
+#      secure: true (default to true)
 
 ```
 

--- a/Security/Http/Cookie/JWTCookieProvider.php
+++ b/Security/Http/Cookie/JWTCookieProvider.php
@@ -14,6 +14,7 @@ final class JWTCookieProvider
     private $defaultSameSite;
     private $defaultPath;
     private $defaultDomain;
+    private $defaultSecure;
 
     /**
      * @param string|null $defaultName
@@ -21,14 +22,16 @@ final class JWTCookieProvider
      * @param string      $defaultPath
      * @param string|null $defaultDomain
      * @param string      $defaultSameSite
+     * @param bool        $defaultSecure
      */
-    public function __construct($defaultName = null, $defaultLifetime = 0, $defaultSameSite = Cookie::SAMESITE_LAX, $defaultPath = '/', $defaultDomain = null)
+    public function __construct($defaultName = null, $defaultLifetime = 0, $defaultSameSite = Cookie::SAMESITE_LAX, $defaultPath = '/', $defaultDomain = null, $defaultSecure = true)
     {
         $this->defaultName = $defaultName;
         $this->defaultLifetime = $defaultLifetime;
         $this->defaultSameSite = $defaultSameSite;
         $this->defaultPath = $defaultPath;
         $this->defaultDomain = $defaultDomain;
+        $this->defaultSecure = $defaultSecure;
     }
 
     /**
@@ -43,10 +46,11 @@ final class JWTCookieProvider
      * @param string|null                        $sameSite
      * @param string|null                        $path
      * @param string|null                        $domain
+     * @param bool|null                          $secure
      *
      * @return Cookie
      */
-    public function createCookie($jwt, $name = null, $expiresAt = null, $sameSite = null, $path = null, $domain = null)
+    public function createCookie($jwt, $name = null, $expiresAt = null, $sameSite = null, $path = null, $domain = null, $secure = null)
     {
         if (!$name && !$this->defaultName) {
             throw new \LogicException(sprintf('The cookie name must be provided, either pass it as 2nd argument of %s or set a default name via the constructor.', __METHOD__));
@@ -62,7 +66,7 @@ final class JWTCookieProvider
             null === $expiresAt ? (time() + $this->defaultLifetime) : $expiresAt,
             $path ?: $this->defaultPath,
             $domain ?: $this->defaultDomain,
-            true,
+            $secure ?: $this->defaultSecure,
             true,
             false,
             $sameSite ?: $this->defaultSameSite


### PR DESCRIPTION
I have added the possibility to choose if the cookie is "secure" or not. This allows when we work in localhost or on a development server that is not in HTTPS that the cookie is created.

I encountered this problem today and I saw that it was not available which is a pity.

See [753](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/753#discussion_r432844990)

Have a nice evening!