### PR TITLE
EventDispatcher-Wrapper for "Symfony<4"-EventDispatcher

### DIFF
--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -6,7 +6,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationFailureEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\BackwardsCompatibleEventDispatcher;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
@@ -24,9 +24,9 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
     protected $dispatcher;
 
     /**
-     * @param ContractsEventDispatcherInterface $dispatcher
+     * @param EventDispatcherInterface $dispatcher
      */
-    public function __construct(ContractsEventDispatcherInterface $dispatcher)
+    public function __construct(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = BackwardsCompatibleEventDispatcher::create($dispatcher);
     }

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationFailureEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\BackwardsCompatibleEventDispatcher;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -19,16 +19,16 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerI
 class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterface
 {
     /**
-     * @var EventDispatcherInterface
+     * @var BackwardsCompatibleEventDispatcher
      */
     protected $dispatcher;
 
     /**
-     * @param EventDispatcherInterface $dispatcher
+     * @param ContractsEventDispatcherInterface $dispatcher
      */
-    public function __construct(EventDispatcherInterface $dispatcher)
+    public function __construct(ContractsEventDispatcherInterface $dispatcher)
     {
-        $this->dispatcher = $dispatcher;
+        $this->dispatcher = BackwardsCompatibleEventDispatcher::create($dispatcher);
     }
 
     /**
@@ -41,11 +41,7 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
             new JWTAuthenticationFailureResponse($exception->getMessageKey())
         );
 
-        if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
-            $this->dispatcher->dispatch($event, Events::AUTHENTICATION_FAILURE);
-        } else {
-            $this->dispatcher->dispatch(Events::AUTHENTICATION_FAILURE, $event);
-        }
+        $this->dispatcher->dispatch($event, Events::AUTHENTICATION_FAILURE);
 
         return $event->getResponse();
     }

--- a/Services/BackwardsCompatibleEventDispatcher.php
+++ b/Services/BackwardsCompatibleEventDispatcher.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Services;
+
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
+
+final class BackwardsCompatibleEventDispatcher
+{
+    /**
+     * @var ContractsEventDispatcherInterface
+     */
+    protected $dispatcher;
+
+    /**
+     * @param ContractsEventDispatcherInterface $dispatcher
+     */
+    private function __construct($dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * @param ContractsEventDispatcherInterface $dispatcher
+     *
+     * @return $this
+     */
+    public static function create($dispatcher)
+    {
+        return new self($dispatcher);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dispatch($event, $eventName = null)
+    {
+        if (!($this->dispatcher instanceof ContractsEventDispatcherInterface)) {
+            return $this->dispatchToLegacyEventDispatcher($eventName, $event);
+        }
+
+        return $this->dispatcher->dispatch($event, $eventName);
+    }
+
+    /**
+     * @deprecated This is a backward-compatibility layer for Symfony<4.
+     *
+     * @param string $eventName
+     * @param object $event
+     *
+     * @return object
+     */
+    private function dispatchToLegacyEventDispatcher($eventName, $event)
+    {
+        return $this->dispatcher->dispatch($eventName, $event);
+    }
+}


### PR DESCRIPTION
@chalasr Hi, about what you said earlier about the backwards-compatibility with Symfony <4; I was wondering why don't you just add your own wrapper for such things?

(for reference: https://github.com/lexik/LexikJWTAuthenticationBundle/pull/774#issuecomment-689544025)