### PR TITLE
Add deprecation message argument to JWTFactory.php

### DIFF
--- a/DependencyInjection/Security/Factory/JWTFactory.php
+++ b/DependencyInjection/Security/Factory/JWTFactory.php
@@ -101,7 +101,7 @@ class JWTFactory implements SecurityFactoryInterface
     {
         $deprecationArgs = [];
         if (method_exists(BaseNode::class, 'getDeprecation')) {
-            $deprecationArgs = ['lexik/jwt-authentication-bundle', '2.7'];
+            $deprecationArgs = ['lexik/jwt-authentication-bundle', '2.7', 'The "%path%.%node%" configuration key is deprecated. Use the "lexik_jwt_authentication.jwt_token_authenticator" Guard authenticator instead.'];
         }
 
         if (method_exists($node, 'setDeprecated')) {


### PR DESCRIPTION
Apologies if the message isn't quite right, but figured it was best to try a PR myself rather than expecting someone else to do it :slightly_smiling_face:.

This should fix the remaining indirect deprecation notice due to the changes made to `setDeprecated()` in Symfony 5.1.

Closes #778