### PR TITLE
Allow token creation from an existing payload

### DIFF
--- a/Resources/doc/2-data-customization.md
+++ b/Resources/doc/2-data-customization.md
@@ -16,8 +16,10 @@ Table of contents
 * [Customizing the response on token not found](#eventsjwt_not_found---customizing-the-response-on-token-not-found)
 * [Customizing the response on expired token](#eventsjwt_expired---customizing-the-response-message-on-expired-token)
 
-Events::JWT_CREATED - Adding custom data or headers to the JWT
+Adding custom data or headers to the JWT
 --------------------------------------------------------------
+
+#### Using Events::JWT_CREATED
 
 By default the JWT payload will contain the username and the token TTL,
 but you can add your own data.
@@ -34,7 +36,7 @@ services:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_created, method: onJWTCreated }
 ```
 
-#### Example: Add client ip to the encoded payload
+##### Example: Add client ip to the encoded payload
 
 ``` php
 // src/App/EventListener/JWTCreatedListener.php
@@ -76,7 +78,7 @@ public function onJWTCreated(JWTCreatedEvent $event)
 }
 ```
 
-#### Example: Override token expiration date calculation to be more flexible
+##### Example: Override token expiration date calculation to be more flexible
 
 ``` php
 // src/App/EventListener/JWTCreatedListener.php
@@ -99,6 +101,16 @@ public function onJWTCreated(JWTCreatedEvent $event)
     $event->setData($payload);
 }
 ```
+
+#### Using a custom payload at JWT creation
+
+If you [create JWT tokens programmatically](./7-manual-token-creation.md), you can add custom data to the JWT using the method `createFromPayload(UserInterface $user, array $payload)`
+
+```php
+$payload = ['foo' => 'bar'];
+
+$jwt = $this->container->get('lexik_jwt_authentication.jwt_manager')->createFromPayload($user);
+``` 
 
 Events::JWT_DECODED - Validating data in the JWT payload
 --------------------------------------------------------

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -61,17 +61,41 @@ class JWTManager implements JWTManagerInterface, JWTTokenManagerInterface
      *
      * @return string The JWT token
      */
-    public function create(UserInterface $user, array $payload = [])
+    public function create(UserInterface $user)
+    {
+        $payload = ['roles' => $user->getRoles()];
+        $this->addUserIdentityToPayload($user, $payload);
+
+        return $this->generateJwtStringAndDispatchEvents($user, $payload);
+    }
+
+    /**
+     * @param UserInterface $user
+     * @param array $payload
+     *
+     * @return string The JWT token
+     */
+    public function createFromPayload(UserInterface $user, array $payload)
     {
         $payload = array_merge(['roles' => $user->getRoles()], $payload);
         $this->addUserIdentityToPayload($user, $payload);
 
+        return $this->generateJwtStringAndDispatchEvents($user, $payload);
+    }
+
+    /**
+     * @param UserInterface $user
+     * @param array $payload
+     *
+     * @return string The JWT token
+     */
+    private function generateJwtStringAndDispatchEvents(UserInterface $user, array $payload)
+    {
         $jwtCreatedEvent = new JWTCreatedEvent($payload, $user);
         if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
             $this->dispatcher->dispatch($jwtCreatedEvent, Events::JWT_CREATED);
         } else {
             $this->dispatcher->dispatch(Events::JWT_CREATED, $jwtCreatedEvent);
-
         }
 
         if ($this->jwtEncoder instanceof HeaderAwareJWTEncoderInterface) {

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -56,42 +56,12 @@ class JWTManager implements JWTManagerInterface, JWTTokenManagerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param UserInterface $user
+     * @param array $payload
+     *
+     * @return string The JWT token
      */
-    public function create(UserInterface $user)
-    {
-        $payload = ['roles' => $user->getRoles()];
-        $this->addUserIdentityToPayload($user, $payload);
-
-        $jwtCreatedEvent = new JWTCreatedEvent($payload, $user);
-        if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
-            $this->dispatcher->dispatch($jwtCreatedEvent, Events::JWT_CREATED);
-        } else {
-            $this->dispatcher->dispatch(Events::JWT_CREATED, $jwtCreatedEvent);
-
-        }
-
-        if ($this->jwtEncoder instanceof HeaderAwareJWTEncoderInterface) {
-            $jwtString = $this->jwtEncoder->encode($jwtCreatedEvent->getData(), $jwtCreatedEvent->getHeader());
-        } else {
-            $jwtString = $this->jwtEncoder->encode($jwtCreatedEvent->getData());
-        }
-
-        $jwtEncodedEvent = new JWTEncodedEvent($jwtString);
-
-        if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
-            $this->dispatcher->dispatch($jwtEncodedEvent, Events::JWT_ENCODED);
-        } else {
-            $this->dispatcher->dispatch(Events::JWT_ENCODED, $jwtEncodedEvent);
-        }
-
-        return $jwtString;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createFromPayload(UserInterface $user, array $payload)
+    public function create(UserInterface $user, array $payload = [])
     {
         $payload = array_merge(['roles' => $user->getRoles()], $payload);
         $this->addUserIdentityToPayload($user, $payload);

--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -91,6 +91,39 @@ class JWTManager implements JWTManagerInterface, JWTTokenManagerInterface
     /**
      * {@inheritdoc}
      */
+    public function createFromPayload(UserInterface $user, array $payload)
+    {
+        $payload = array_merge(['roles' => $user->getRoles()], $payload);
+        $this->addUserIdentityToPayload($user, $payload);
+
+        $jwtCreatedEvent = new JWTCreatedEvent($payload, $user);
+        if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
+            $this->dispatcher->dispatch($jwtCreatedEvent, Events::JWT_CREATED);
+        } else {
+            $this->dispatcher->dispatch(Events::JWT_CREATED, $jwtCreatedEvent);
+
+        }
+
+        if ($this->jwtEncoder instanceof HeaderAwareJWTEncoderInterface) {
+            $jwtString = $this->jwtEncoder->encode($jwtCreatedEvent->getData(), $jwtCreatedEvent->getHeader());
+        } else {
+            $jwtString = $this->jwtEncoder->encode($jwtCreatedEvent->getData());
+        }
+
+        $jwtEncodedEvent = new JWTEncodedEvent($jwtString);
+
+        if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
+            $this->dispatcher->dispatch($jwtEncodedEvent, Events::JWT_ENCODED);
+        } else {
+            $this->dispatcher->dispatch(Events::JWT_ENCODED, $jwtEncodedEvent);
+        }
+
+        return $jwtString;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function decode(TokenInterface $token)
     {
         if (!($payload = $this->jwtEncoder->decode($token->getCredentials()))) {

--- a/Services/JWTManagerInterface.php
+++ b/Services/JWTManagerInterface.php
@@ -11,11 +11,16 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @deprecated since 2.0, removed in 3.0. Use {@link JWTTokenManagerInterface} instead
  *
  * @author Nicolas Cabot <n.cabot@lexik.fr>
- *
- * @method create(UserInterface $user, array $payload = []);
  */
 interface JWTManagerInterface
 {
+    /**
+     * @param UserInterface $user
+     *
+     * @return string The JWT token
+     */
+    public function create(UserInterface $user);
+
     /**
      * @param TokenInterface $token
      *

--- a/Services/JWTManagerInterface.php
+++ b/Services/JWTManagerInterface.php
@@ -11,16 +11,11 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @deprecated since 2.0, removed in 3.0. Use {@link JWTTokenManagerInterface} instead
  *
  * @author Nicolas Cabot <n.cabot@lexik.fr>
+ *
+ * @method create(UserInterface $user, array $payload = []);
  */
 interface JWTManagerInterface
 {
-    /**
-     * @param UserInterface $user
-     *
-     * @return string The JWT token
-     */
-    public function create(UserInterface $user);
-
     /**
      * @param TokenInterface $token
      *

--- a/Services/JWTTokenManagerInterface.php
+++ b/Services/JWTTokenManagerInterface.php
@@ -10,11 +10,19 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * JWT tokens.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
+ * @author Eric Lannez <eric.lannez@gmail.com>
  *
- * @method create(UserInterface $user, array $payload = []);
+ * @method createFromPayload(UserInterface $user, array $payload = []);
  */
 interface JWTTokenManagerInterface
 {
+    /**
+     * @param UserInterface $user
+     *
+     * @return string The JWT token
+     */
+    public function create(UserInterface $user);
+
     /**
      * @param TokenInterface $token
      *

--- a/Services/JWTTokenManagerInterface.php
+++ b/Services/JWTTokenManagerInterface.php
@@ -10,6 +10,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * JWT tokens.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
+ *
+ * @method createFromPayload(UserInterface $user, array $payload = []);
  */
 interface JWTTokenManagerInterface
 {

--- a/Services/JWTTokenManagerInterface.php
+++ b/Services/JWTTokenManagerInterface.php
@@ -11,17 +11,10 @@ use Symfony\Component\Security\Core\User\UserInterface;
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  *
- * @method createFromPayload(UserInterface $user, array $payload = []);
+ * @method create(UserInterface $user, array $payload = []);
  */
 interface JWTTokenManagerInterface
 {
-    /**
-     * @param UserInterface $user
-     *
-     * @return string The JWT token
-     */
-    public function create(UserInterface $user);
-
     /**
      * @param TokenInterface $token
      *

--- a/Tests/Services/JWTManagerTest.php
+++ b/Tests/Services/JWTManagerTest.php
@@ -66,58 +66,8 @@ class JWTManagerTest extends TestCase
             ->willReturn('secrettoken');
 
         $manager = new JWTManager($encoder, $dispatcher, 'username');
-        $this->assertEquals('secrettoken', $manager->create(new User('user', 'password')));
-    }
-
-    /**
-     * test create.
-     */
-    public function testCreateFromPayload()
-    {
-        $dispatcher = $this->getEventDispatcherMock();
-
-        if ($dispatcher instanceof ContractsEventDispatcherInterface) {
-            $dispatcher
-                ->expects($this->at(0))
-                ->method('dispatch')
-                ->with(
-                    $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent'),
-                    $this->equalTo(Events::JWT_CREATED)
-                );
-
-            $dispatcher
-                ->expects($this->at(1))
-                ->method('dispatch')
-                ->with(
-                    $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent'),
-                    $this->equalTo(Events::JWT_ENCODED)
-                );
-        } else {
-            $dispatcher
-                ->expects($this->at(0))
-                ->method('dispatch')
-                ->with(
-                    $this->equalTo(Events::JWT_CREATED),
-                    $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent')
-                );
-            $dispatcher
-                ->expects($this->at(1))
-                ->method('dispatch')
-                ->with(
-                    $this->equalTo(Events::JWT_ENCODED),
-                    $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent')
-                );
-        }
-
-        $encoder = $this->getJWTEncoderMock();
-        $encoder
-            ->expects($this->once())
-            ->method('encode')
-            ->willReturn('secrettoken');
-
-        $manager = new JWTManager($encoder, $dispatcher, 'username');
         $payload = ['foo' => 'bar'];
-        $this->assertEquals('secrettoken', $manager->createFromPayload(new User('user', 'password'), $payload));
+        $this->assertEquals('secrettoken', $manager->create(new User('user', 'password'), $payload));
     }
 
     /**

--- a/Tests/Services/JWTManagerTest.php
+++ b/Tests/Services/JWTManagerTest.php
@@ -70,6 +70,57 @@ class JWTManagerTest extends TestCase
     }
 
     /**
+     * test create.
+     */
+    public function testCreateFromPayload()
+    {
+        $dispatcher = $this->getEventDispatcherMock();
+
+        if ($dispatcher instanceof ContractsEventDispatcherInterface) {
+            $dispatcher
+                ->expects($this->at(0))
+                ->method('dispatch')
+                ->with(
+                    $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent'),
+                    $this->equalTo(Events::JWT_CREATED)
+                );
+
+            $dispatcher
+                ->expects($this->at(1))
+                ->method('dispatch')
+                ->with(
+                    $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent'),
+                    $this->equalTo(Events::JWT_ENCODED)
+                );
+        } else {
+            $dispatcher
+                ->expects($this->at(0))
+                ->method('dispatch')
+                ->with(
+                    $this->equalTo(Events::JWT_CREATED),
+                    $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent')
+                );
+            $dispatcher
+                ->expects($this->at(1))
+                ->method('dispatch')
+                ->with(
+                    $this->equalTo(Events::JWT_ENCODED),
+                    $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent')
+                );
+        }
+
+        $encoder = $this->getJWTEncoderMock();
+        $encoder
+            ->expects($this->once())
+            ->method('encode')
+            ->willReturn('secrettoken');
+
+        $manager = new JWTManager($encoder, $dispatcher, 'username');
+        $payload = ['foo' => 'bar'];
+        $this->assertEquals('secrettoken', $manager->createFromPayload(new User('user', 'password'), $payload));
+    }
+
+    /**
      * test decode.
      */
     public function testDecode()


### PR DESCRIPTION
Add virtual method in JWTTokenManagerInterface to allow token creation from an existing payload