### PR TITLE
Fix Symfony 5.2 getProviderKey deprecation

### DIFF
--- a/Security/Authentication/Token/JWTUserToken.php
+++ b/Security/Authentication/Token/JWTUserToken.php
@@ -26,7 +26,7 @@ class JWTUserToken extends AbstractToken implements GuardTokenInterface
     /**
      * {@inheritdoc}
      */
-    public function __construct(array $roles = [], UserInterface $user = null, $rawToken = null, $providerKey = null)
+    public function __construct(array $roles = [], UserInterface $user = null, $rawToken = null, $firewallName = null)
     {
         parent::__construct($roles);
 
@@ -37,7 +37,7 @@ class JWTUserToken extends AbstractToken implements GuardTokenInterface
         $this->setRawToken($rawToken);
         $this->setAuthenticated(true);
 
-        $this->providerKey = $providerKey;
+        $this->providerKey = $firewallName;
     }
 
     /**
@@ -57,11 +57,19 @@ class JWTUserToken extends AbstractToken implements GuardTokenInterface
     }
 
     /**
-     * Returns the provider key.
-     *
-     * @return string The provider key
+     * @deprecated since 2.10, use getFirewallName() instead
      */
     public function getProviderKey()
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated since version 2.10 and will be removed in 3.0. Use "%s::getFirewallName()" instead.', __METHOD__, self::class), E_USER_DEPRECATED);
+
+        return $this->getFirewallName();
+    }
+
+    /**
+     * @return string
+     */
+    public function getFirewallName()
     {
         return $this->providerKey;
     }


### PR DESCRIPTION
👋   Hi

> Since symfony/security-http 5.2: Method "Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken::getProviderKey()" has been deprecated, rename it to "getFirewallName()" instead.

 from https://github.com/symfony/symfony/pull/37942