### PR TITLE
Set Token on ExpiredTokenException

### DIFF
--- a/Security/Guard/JWTTokenAuthenticator.php
+++ b/Security/Guard/JWTTokenAuthenticator.php
@@ -118,7 +118,9 @@ class JWTTokenAuthenticator extends AbstractGuardAuthenticator
             $preAuthToken->setPayload($payload);
         } catch (JWTDecodeFailureException $e) {
             if (JWTDecodeFailureException::EXPIRED_TOKEN === $e->getReason()) {
-                throw new ExpiredTokenException();
+                $expiredTokenException = new ExpiredTokenException();
+                $expiredTokenException->setToken($preAuthToken);
+                throw $expiredTokenException;
             }
 
             throw new InvalidTokenException('Invalid JWT Token', 0, $e);


### PR DESCRIPTION
Set Token on ExpiredTokenException

This can be useful when you want to fetch the token when it is expired. 