### PR TITLE
Update LcobucciJWSProvider.php

### DIFF
--- a/Services/JWSProvider/LcobucciJWSProvider.php
+++ b/Services/JWSProvider/LcobucciJWSProvider.php
@@ -116,7 +116,7 @@ class LcobucciJWSProvider implements JWSProviderInterface
             if ($this->legacyJWTApi) {
                 $jws->setExpiration($exp);
             } else {
-                $jws->expiresAt($exp instanceof \DateTimeImmutable ? $exp : new \DateTimeImmutable("@$exp"));
+                $jws->expiresAt($exp instanceof \DateTimeImmutable ? $exp->getTimestamp() : (new \DateTimeImmutable("@$exp"))->getTimestamp());
             }
         }
 


### PR DESCRIPTION
Lcobucci\JWT\Builder::expiresAt now accept int as first argument, so without that fix it will not work and will throw an error: "Object of class DateTimeImmutable could not be converted to int"

<img width="860" alt="Снимок экрана 2020-11-28 в 19 29 44" src="https://user-images.githubusercontent.com/3224226/100520678-13230780-31b0-11eb-9ff2-776920ec2406.png">

(tested with php7.4 +  lexik/jwt-authentication-bundle:v2.10.1)
