### PR TITLE
Remove duplicate client from phpunit example

### DIFF
--- a/Resources/doc/3-functional-testing.md
+++ b/Resources/doc/3-functional-testing.md
@@ -53,7 +53,6 @@ protected function createAuthenticatedClient($username = 'user', $password = 'pa
 
     $data = json_decode($client->getResponse()->getContent(), true);
 
-    $client = static::createClient();
     $client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $data['token']));
 
     return $client;


### PR DESCRIPTION
`$client = static::createClient();` is already called line 41 and should be called only once per test function.
Closes https://github.com/lexik/LexikJWTAuthenticationBundle/issues/783