### PR TITLE
Add parameter name in PHPDocs param comment

### DIFF
--- a/Services/JWTTokenManagerInterface.php
+++ b/Services/JWTTokenManagerInterface.php
@@ -29,7 +29,7 @@ interface JWTTokenManagerInterface
     /**
      * Sets the field used as identifier to load an user from a JWT payload.
      *
-     * @param string
+     * @param string $field
      */
     public function setUserIdentityField($field);
 

--- a/Services/KeyLoader/KeyLoaderInterface.php
+++ b/Services/KeyLoader/KeyLoaderInterface.php
@@ -18,7 +18,7 @@ interface KeyLoaderInterface
     /**
      * Loads a key from a given type (public or private).
      *
-     * @param resource|string|null
+     * @param resource|string|null $type
      *
      * @return resource|string|null
      */


### PR DESCRIPTION
As Psalm return the following errors:

```
ERROR: InvalidDocblock - vendor/lexik/jwt-authentication-bundle/Services/KeyLoader/KeyLoaderInterface.php:25:5 - Badly-formatted @param in docblock for Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\KeyLoaderInterface::loadKey (see https://psalm.dev/008)
    /**
     * Loads a key from a given type (public or private).
     *
     * @param resource|string|null
     *
     * @return resource|string|null
     */
    public function loadKey($type);
```

```
ERROR: InvalidDocblock - vendor/lexik/jwt-authentication-bundle/Services/JWTTokenManagerInterface.php:38:5 - Badly-formatted @param in docblock for Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface::setUserIdentityField (see https://psalm.dev/008)
    /**
     * Sets the field used as identifier to load an user from a JWT payload.
     *
     * @param string
     */
    public function setUserIdentityField($field);
```