### PR TITLE
Remove extra \@param annotation from JWTManager::create

### DIFF
--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -57,7 +57,6 @@ class JWTManager implements JWTManagerInterface, JWTTokenManagerInterface
 
     /**
      * @param UserInterface $user
-     * @param array $payload
      *
      * @return string The JWT token
      */


### PR DESCRIPTION
Symfony gives annoying deprecation notices when using DebugClassLoader becouse of this extra annotation