### PR TITLE
Make AbstractKeyLoader::getSigningKey() and AbstractKeyLoader::getPublicKey public.

### DIFF
--- a/Services/KeyLoader/AbstractKeyLoader.php
+++ b/Services/KeyLoader/AbstractKeyLoader.php
@@ -46,12 +46,12 @@ abstract class AbstractKeyLoader implements KeyLoaderInterface
         return $this->passphrase;
     }
 
-    protected function getSigningKey()
+    public function getSigningKey()
     {
         return is_file($this->signingKey) ? $this->readKey(self::TYPE_PRIVATE) : $this->signingKey;
     }
 
-    protected function getPublicKey()
+    public function getPublicKey()
     {
         return is_file($this->publicKey) ? $this->readKey(self::TYPE_PUBLIC) : $this->publicKey;
     }

--- a/Services/KeyLoader/KeyLoaderInterface.php
+++ b/Services/KeyLoader/KeyLoaderInterface.php
@@ -7,7 +7,8 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader;
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  *
- * @internal
+ * @method string|null getPublicKey()
+ * @method string|null getSigningKey()
  */
 interface KeyLoaderInterface
 {


### PR DESCRIPTION
This issue:

- [x] Make `AbstractKeyLoader::getSigningKey()` public instead of `protected`.
- [x] Make `AbstractKeyLoader::getPublicKey()` public instead of `protected`.
- [x] Update the interface `KeyLoaderInterface` with `@method` annotations.


Making them public instead of protected make possible the use of the very useful Decorator pattern.

Useful when one wants to replace one specific part of a bundle.

This PR relates to #831 but I would like to receive some feedback on this before merging.