### PR TITLE
[Security] On Authentication failure, replace MessageData

### DIFF
--- a/Security/Guard/JWTTokenAuthenticator.php
+++ b/Security/Guard/JWTTokenAuthenticator.php
@@ -163,7 +163,8 @@ class JWTTokenAuthenticator extends AbstractGuardAuthenticator
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $authException)
     {
-        $response = new JWTAuthenticationFailureResponse($authException->getMessageKey());
+        $errorMessage = strtr($authException->getMessageKey(), $authException->getMessageData());
+        $response = new JWTAuthenticationFailureResponse($errorMessage);
 
         if ($authException instanceof ExpiredTokenException) {
             $event = new JWTExpiredEvent($authException, $response);

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -32,9 +32,10 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
+        $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());
         $event = new AuthenticationFailureEvent(
             $exception,
-            new JWTAuthenticationFailureResponse($exception->getMessageKey())
+            new JWTAuthenticationFailureResponse($errorMessage)
         );
 
         $this->dispatcher->dispatch($event, Events::AUTHENTICATION_FAILURE);


### PR DESCRIPTION
When Authentication fail, the returned message contains: `%var%` that is not replaced. 
Eg with login_throttling:

> "Too many failed login attempts, please try again in %minutes% minute."
> no replace %minutes%

In symfony they use the translator or the `strtr()` function if the translator is not used, in the case of an API login, I'm not sure the Translation is needed, then I directly use the `strtr()` function.