### PR TITLE
Remove development files from releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.* export-ignore
+*.md export-ignore
+Resources/doc export-ignore
+Tests export-ignore
+phpunit.xml.dist export-ignore
+phpstan.neon export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,4 @@ phpunit.xml
 build
 vendor
 composer.lock
-composer.phar
-.idea
 .phpunit.result.cache


### PR DESCRIPTION
Environment specific files were also removed from `.gitattributes`. They should be [globally ignored](https://docs.github.com/es/github/getting-started-with-github/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer) in the environment they exist.