### PR TITLE
Handle misc. Symfony 5.3 deprecations, update CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,37 @@ jobs:
 
             - name: "Run PHPUnit Tests"
               run: "composer test"
+    php-72:
+        name: PHP 7.2 / Symfony 5.1
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v2"
+              with:
+                  fetch-depth: 2
+
+            - name: "Install PHP 7.2"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  php-version: "7.2"
+
+            - name: "Cache composer packages"
+              uses: "actions/cache@v2"
+              with:
+                  path: "~/.composer/cache"
+                  key: "php-7.2-composer-locked-${{ hashFiles('composer.lock') }}"
+                  restore-keys: "php-7.2-composer-locked-"
+
+            - name: "Install Symfony 5.1"
+              run: "composer require symfony/symfony:5.1.* --no-update"
+
+            - name: "Install dependencies with composer"
+              run: "composer update --no-interaction"
+
+            - name: "Run PHPUnit Tests"
+              run: "composer test"
     php-73:
-        name: PHP 7.3 / Symfony 5.1
+        name: PHP 7.3 / Symfony 5.2
         runs-on: ubuntu-latest
         steps:
             - name: "Checkout"
@@ -55,8 +84,8 @@ jobs:
                   key: "php-7.3-composer-locked-${{ hashFiles('composer.lock') }}"
                   restore-keys: "php-7.3-composer-locked-"
 
-            - name: "Install Symfony 5.1"
-              run: "composer require symfony/symfony:5.1.* --no-update"
+            - name: "Install Symfony 5.2"
+              run: "composer require symfony/symfony:5.2.* --no-update"
 
             - name: "Install dependencies with composer"
               run: "composer update --no-interaction"
@@ -64,7 +93,7 @@ jobs:
             - name: "Run PHPUnit Tests"
               run: "composer test"
     php-74:
-        name: PHP 7.4 / Symfony 5.2
+        name: PHP 7.4 / Symfony 5.3
         runs-on: ubuntu-latest
         steps:
             - name: "Checkout"
@@ -84,8 +113,8 @@ jobs:
                   key: "php-7.4-composer-locked-${{ hashFiles('composer.lock') }}"
                   restore-keys: "php-7.4-composer-locked-"
 
-            - name: "Install Symfony 5.1"
-              run: "composer require symfony/symfony:5.2.* --no-update"
+            - name: "Install Symfony 5.3"
+              run: "composer require symfony/symfony:5.3.* --no-update"
 
             - name: "Install dependencies with composer"
               run: "composer update --no-interaction"
@@ -93,7 +122,7 @@ jobs:
             - name: "Run PHPUnit Tests"
               run: "composer test"
     php8:
-        name: PHP 8 / Symfony 5.x-dev
+        name: PHP 8 / Symfony 5.4@dev
         runs-on: ubuntu-latest
         steps:
             - name: "Checkout"
@@ -114,7 +143,7 @@ jobs:
                   restore-keys: "php-8-composer-locked-"
 
             - name: "Install Symfony 5.4"
-              run: "composer require symfony/symfony:5.x-dev --no-update"
+              run: "composer require symfony/symfony:5.4.*@dev --no-update"
 
             - name: "Install dependencies with composer"
               run: "composer update --no-interaction"

--- a/Command/GenerateTokenCommand.php
+++ b/Command/GenerateTokenCommand.php
@@ -76,9 +76,13 @@ class GenerateTokenCommand extends Command
             }
         }
 
-        $token = $this->tokenManager->create(
-            $userProvider->loadUserByUsername($input->getArgument('username'))
-        );
+        if (method_exists($userProvider, 'loadUserByIdentifier')) {
+            $user = $userProvider->loadUserByIdentifier($input->getArgument('username'));
+        } else {
+            $user = $userProvider->loadUserByUsername($input->getArgument('username'));
+        }
+
+        $token = $this->tokenManager->create($user);
 
         $output->writeln([
             '',

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -70,7 +70,7 @@ class LexikJWTAuthenticationExtension extends Extension
         $container->setParameter('lexik_jwt_authentication.clock_skew', $config['clock_skew']);
         $container->setParameter('lexik_jwt_authentication.user_identity_field', $config['user_identity_field']);
 
-        $user_id_claim = $config['user_id_claim'] ? $config['user_id_claim'] : $config['user_identity_field'];
+        $user_id_claim = $config['user_id_claim'] ?: $config['user_identity_field'];
         $container->setParameter('lexik_jwt_authentication.user_id_claim', $user_id_claim);
         $encoderConfig = $config['encoder'];
 

--- a/DependencyInjection/Security/Factory/JWTUserFactory.php
+++ b/DependencyInjection/Security/Factory/JWTUserFactory.php
@@ -8,7 +8,6 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\User
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
 /**
  * Creates the `lexik_jwt` user provider.
@@ -21,14 +20,8 @@ final class JWTUserFactory implements UserProviderFactoryInterface
 {
     public function create(ContainerBuilder $container, $id, $config)
     {
-        if (class_exists(ChildDefinition::class)) {
-            $definition = new ChildDefinition('lexik_jwt_authentication.security.jwt_user_provider');
-        } else {
-            $definition = new DefinitionDecorator('lexik_jwt_authentication.security.jwt_user_provider');
-        }
-
-        $definition = $container->setDefinition($id, $definition);
-        $definition->replaceArgument(0, $config['class']);
+        $container->setDefinition($id, new ChildDefinition('lexik_jwt_authentication.security.jwt_user_provider'))
+            ->replaceArgument(0, $config['class']);
     }
 
     public function getKey()

--- a/Security/Authentication/Provider/JWTProvider.php
+++ b/Security/Authentication/Provider/JWTProvider.php
@@ -104,6 +104,10 @@ class JWTProvider implements AuthenticationProviderInterface
             throw $this->createAuthenticationException();
         }
 
+        if (method_exists($this->userProvider, 'loadUserByIdentifier')) {
+            return $this->userProvider->loadUserByIdentifier($payload[$this->userIdClaim]);
+        }
+
         return $this->userProvider->loadUserByUsername($payload[$this->userIdClaim]);
     }
 

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -10,7 +10,6 @@ use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserTo
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Guard\JWTTokenAuthenticator;
 use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;

--- a/Tests/Functional/Bundle/Controller/TestController.php
+++ b/Tests/Functional/Bundle/Controller/TestController.php
@@ -12,7 +12,7 @@ class TestController
         return new JsonResponse([
             'class' => get_class($user),
             'roles' => $user->getRoles(),
-            'username' => $user->getUsername(),
+            'username' => method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername(),
         ]);
     }
 }

--- a/Tests/Functional/CompleteTokenAuthenticationTest.php
+++ b/Tests/Functional/CompleteTokenAuthenticationTest.php
@@ -4,6 +4,7 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Tests\Stubs\JWTUser;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\User;
 
 /**
@@ -33,6 +34,8 @@ class CompleteTokenAuthenticationTest extends TestCase
 
         if ('lexik_jwt' === static::$kernel->getUserProvider()) {
             $this->assertSame(JWTUser::class, $content['class']);
+        } elseif (class_exists(InMemoryUser::class)) {
+            $this->assertSame(InMemoryUser::class, $content['class']);
         } else {
             $this->assertSame(User::class, $content['class']);
         }

--- a/Tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/Tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
@@ -9,6 +9,9 @@ use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * AuthenticationSuccessHandlerTest.
@@ -136,18 +139,13 @@ class AuthenticationSuccessHandlerTest extends TestCase
         return $token;
     }
 
-    private function getUser()
+    private function getUser(): UserInterface
     {
-        $user = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')
-            ->getMock();
+        if (class_exists(InMemoryUser::class)) {
+            return new InMemoryUser('username', 'password');
+        }
 
-        $user
-            ->expects($this->any())
-            ->method('getUsername')
-            ->will($this->returnValue('username'));
-
-        return $user;
+        return new User('username', 'password');
     }
 
     private function getJWTManager($token = null)

--- a/Tests/Security/User/JWTUserProviderTest.php
+++ b/Tests/Security/User/JWTUserProviderTest.php
@@ -32,7 +32,7 @@ class JWTUserProviderTest extends TestCase
         $user = $userProvider->loadUserByUsername('lexik');
 
         $this->assertInstanceOf(JWTUser::class, $user);
-        $this->assertSame('lexik', $user->getUsername());
+        $this->assertSame('lexik', method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername());
 
         $this->assertSame($userProvider->loadUserByUsername('lexik'), $user, 'User instances should be cached.');
     }

--- a/Tests/Services/JWTManagerTest.php
+++ b/Tests/Services/JWTManagerTest.php
@@ -8,7 +8,9 @@ use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
 use Lexik\Bundle\JWTAuthenticationBundle\Tests\Stubs\User as CustomUser;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -40,7 +42,7 @@ class JWTManagerTest extends TestCase
             ->willReturn('secrettoken');
 
         $manager = new JWTManager($encoder, $dispatcher, 'username');
-        $this->assertEquals('secrettoken', $manager->create(new User('user', 'password')));
+        $this->assertEquals('secrettoken', $manager->create($this->createUser('user', 'password')));
     }
 
     /**
@@ -66,7 +68,7 @@ class JWTManagerTest extends TestCase
 
         $manager = new JWTManager($encoder, $dispatcher, 'username');
         $payload = ['foo' => 'bar'];
-        $this->assertEquals('secrettoken', $manager->createFromPayload(new User('user', 'password'), $payload));
+        $this->assertEquals('secrettoken', $manager->createFromPayload($this->createUser('user', 'password'), $payload));
     }
 
     /**
@@ -156,5 +158,14 @@ class JWTManagerTest extends TestCase
             ->getMockBuilder(EventDispatcherInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
+    }
+
+    private function createUser(string $username, string $password): UserInterface
+    {
+        if (class_exists(InMemoryUser::class)) {
+            return new InMemoryUser($username, $password);
+        }
+
+        return new User($username, $password);
     }
 }

--- a/Tests/Stubs/User.php
+++ b/Tests/Stubs/User.php
@@ -73,6 +73,14 @@ final class User implements UserInterface
     /**
      * {@inheritdoc}
      */
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function eraseCredentials()
     {
     }


### PR DESCRIPTION
This PR takes a stab at handling some of the Security component deprecations in Symfony 5.3 by adding in the relevant compat checks to use the newer APIs when available and falling back to the deprecated APIs when not.  I've also cleared out some compat code that was there to support Symfony <4.4 and is no longer needed.  Lastly, a CI build for Symfony 5.3 is added in and the 5.x-dev build adjusted to target the 5.4 branch.