### PR TITLE
Fix Changelog dates for releases 2.10.6 <=> 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,37 +3,37 @@ CHANGELOG
 
 For a diff between two versions https://github.com/lexik/LexikJWTAuthenticationBundle/compare/v1.0.0...v2.12.0
 
-## [2.12.0](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.12.0) (2020-06-23)
+## [2.12.0](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.12.0) (2021-06-23)
 
 * feature [\#872](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/872) Add new `jwt` authenticator for Symfony 5.3+ Security system ([TristanPouliquen](https://github.com/TristanPouliquen), [chalasr](https://github.com/chalasr))
 * bug [\#878](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/878) Handle misc. Symfony 5.3 deprecations, update CI config ([mbabker](https://github.com/mbabker))
 * bug [\#864](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/864) Remove development files from releases ([phansys](https://github.com/phansys))
 
-## [2.11.3](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.11.3) (2020-05-12)
+## [2.11.3](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.11.3) (2021-05-12)
 
 * bug [a175d6dab9](https://github.com/lexik/LexikJWTAuthenticationBundle/commit/a175d6dab968d93e96a3e4f80c495435f71d5eb7) Prevent user enumeration via response content ([chalasr](https://github.com/chalasr))
 
-## [2.11.2](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.11.2) (2020-02-17)
+## [2.11.2](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.11.2) (2021-02-17)
 
 * bug [\#840](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/840) [Security] On Authentication failure, replace MessageData ([mpiot](https://github.com/mpiot))
 * bug [\#838](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/838) Fix wiring GenerateKeyPairCommand when key paths are null ([chalasr](https://github.com/chalasr))
 
-## [2.11.1](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.11.1) (2020-02-10)
+## [2.11.1](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.11.1) (2021-02-10)
 
 * bug [\#835](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/835) Fix #834: Re-add namshi/jose as required dependency until v3 ([filisko](https://github.com/filisko))
 
-## [2.11.0](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.11.0) (2020-02-9)
+## [2.11.0](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.11.0) (2021-02-9)
 
 * bug [\#833](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/833) KeyLoaderInterface::getPassphrase() might return null and we need a string ([drupol](https://github.com/drupol))
 * feature [\#832](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/832) Make AbstractKeyLoader::getSigningKey() and AbstractKeyLoader::getPublicKey public ([drupol](https://github.com/drupol))
 * feature [\#817](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/817) Feat: add keypair generation command ([bpolaszek](https://github.com/bpolaszek))
 * feature [\#816](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/816) Remove support for lcobucci/jwt <3.4 & symfony/* <4.4 ([chalasr](https://github.com/chalasr))
 
-## [2.10.7](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.10.7) (2020-05-12)
+## [2.10.7](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.10.7) (2021-05-12)
 
 * bug [a175d6dab9](https://github.com/lexik/LexikJWTAuthenticationBundle/commit/a175d6dab968d93e96a3e4f80c495435f71d5eb7) Prevent user enumeration via response content ([chalasr](https://github.com/chalasr))
 
-## [2.10.6](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.10.6) (2020-01-20)
+## [2.10.6](https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.10.6) (2021-01-20)
 
 * bug [\#827](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/827) Use named constructor for lcobucci/jwt Ecdsa signers ([chalasr](https://github.com/chalasr))
 * bug [\#826](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/826) Fix creating tokens when iat is already set in the payload ([chalasr](https://github.com/chalasr))


### PR DESCRIPTION
`CHANGELOG.md` is showing incorrect year for releases since 2.10.6; giving the appearance of an inactive repository.