### PR TITLE
Fix BC layer around JWTTokenManagerInterface

### DIFF
--- a/DependencyInjection/Security/Factory/JWTAuthenticatorFactory.php
+++ b/DependencyInjection/Security/Factory/JWTAuthenticatorFactory.php
@@ -17,11 +17,11 @@ use Symfony\Component\DependencyInjection\Reference;
 class JWTAuthenticatorFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
 {
     /**
-     * {@inheritdoc}
+     * @throws \LogicException
      */
     public function create(ContainerBuilder $container, $id, $config, $userProvider, $defaultEntryPoint)
     {
-        return [];
+        throw new \LogicException('This method is implemented for BC purpose and should never be called.');
     }
 
     /**

--- a/Security/Authenticator/JWTAuthenticator.php
+++ b/Security/Authenticator/JWTAuthenticator.php
@@ -92,7 +92,7 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
         $token = $this->getTokenExtractor()->extract($request);
 
         try {
-            if (!$payload = $this->jwtManager->decodeFromJsonWebToken($token)) {
+            if (!$payload = $this->jwtManager->parse($token)) {
                 throw new InvalidTokenException('Invalid JWT Token');
             }
         } catch (JWTDecodeFailureException $e) {

--- a/Services/JWTTokenManagerInterface.php
+++ b/Services/JWTTokenManagerInterface.php
@@ -13,7 +13,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @author Robin Chalas <robin.chalas@gmail.com>
  * @author Eric Lannez <eric.lannez@gmail.com>
  *
- * @method createFromPayload(UserInterface $user, array $payload = []);
+ * @method string createFromPayload(UserInterface $user, array $payload = []);
+ * @method array parse(string $token) Parses a raw JWT token and returns its payload
  */
 interface JWTTokenManagerInterface
 {
@@ -27,12 +28,6 @@ interface JWTTokenManagerInterface
      * @throws JWTDecodeFailureException
      */
     public function decode(TokenInterface $token);
-
-    /**
-     * @return array|false The JWT token payload or false if an error occurs
-     * @throws JWTDecodeFailureException
-     */
-    public function decodeFromJsonWebToken(string $jwtToken);
 
     /**
      * Sets the field used as identifier to load an user from a JWT payload.

--- a/Tests/Services/JWTManagerTest.php
+++ b/Tests/Services/JWTManagerTest.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Services;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTDecodedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
@@ -93,6 +94,27 @@ class JWTManagerTest extends TestCase
 
         $manager = new JWTManager($encoder, $dispatcher, 'username');
         $this->assertEquals(['foo' => 'bar'], $manager->decode($this->getJWTUserTokenMock()));
+    }
+
+    public function testParse()
+    {
+        $dispatcher = $this->getEventDispatcherMock();
+        $dispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                $this->isInstanceOf(JWTDecodedEvent::class),
+                $this->equalTo(Events::JWT_DECODED)
+            );
+
+        $encoder = $this->getJWTEncoderMock();
+        $encoder
+            ->expects($this->once())
+            ->method('decode')
+            ->willReturn(['foo' => 'bar']);
+
+        $manager = new JWTManager($encoder, $dispatcher, 'username');
+        $this->assertEquals(['foo' => 'bar'], $manager->parse('jwt'));
     }
 
     /**


### PR DESCRIPTION
Renaming `decodeFromJsonWebToken()` to `parse()` btw. 
Also I'm thinking to deprecate `decode()` in the next minor as it's redundant with `JWTEncoderInterface::decode` and having a security token as argument is not adapted to the new Symfony authenticator system.