### PR TITLE
Removing @final for JWTUser constructor

### DIFF
--- a/Security/User/JWTUser.php
+++ b/Security/User/JWTUser.php
@@ -14,9 +14,6 @@ class JWTUser implements JWTUserInterface
     private $userIdentifier;
     private $roles;
 
-    /**
-     * @final
-     */
     public function __construct(string $userIdentifier, array $roles = [])
     {
         $this->userIdentifier = $userIdentifier;


### PR DESCRIPTION
The "@final" annotation for the JWTUser constructor is somewhat inconsistent with the documentation which tells "Note: You can extend the default JWTUser class if that fits your needs." at https://github.com/lexik/LexikJWTAuthenticationBundle/blob/2.x/Resources/doc/8-jwt-user-provider.md