### PR TITLE
Added argument to AuthenticationSuccessHandler to stop token from being removed from response

### DIFF
--- a/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -27,15 +27,17 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
 
     protected $jwtManager;
     protected $dispatcher;
+    protected $removeTokenFromBodyWhenCookiesUsed;
 
     /**
      * @param iterable|JWTCookieProvider[] $cookieProviders
      */
-    public function __construct(JWTTokenManagerInterface $jwtManager, EventDispatcherInterface $dispatcher, $cookieProviders = [])
+    public function __construct(JWTTokenManagerInterface $jwtManager, EventDispatcherInterface $dispatcher, $cookieProviders = [], bool $removeTokenFromBodyWhenCookiesUsed = true)
     {
         $this->jwtManager = $jwtManager;
         $this->dispatcher = $dispatcher;
         $this->cookieProviders = $cookieProviders;
+        $this->removeTokenFromBodyWhenCookiesUsed = $removeTokenFromBodyWhenCookiesUsed;
     }
 
     /**
@@ -63,7 +65,7 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
         $this->dispatcher->dispatch($event, Events::AUTHENTICATION_SUCCESS);
         $responseData = $event->getData();
 
-        if ($jwtCookies) {
+        if ($jwtCookies && $this->removeTokenFromBodyWhenCookiesUsed) {
             unset($responseData['token']);
         }
 


### PR DESCRIPTION
Fixes #909 (the handler cannot be used when API and form login are used in the same application).

To use this feature, define the handler as success handler on the firewall
```yaml
security:
  firewalls:
    main:
      json_login:
         check_path: my_login_check
         success_handler: lexik_jwt_authentication.handler.authentication_success
         failure_handler: lexik_jwt_authentication.handler.authentication_failure
```

And then define the fourth argument of the handler in your service.yaml:
```yaml
services:
    Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler:
        arguments:
            $removeTokenFromBodyWhenCookiesUsed: false
```