### PR TITLE
Allow to use custom authenticator by extending JWTAuthenticator

### DIFF
--- a/DependencyInjection/Security/Factory/JWTAuthenticatorFactory.php
+++ b/DependencyInjection/Security/Factory/JWTAuthenticatorFactory.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory;
 
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
@@ -45,15 +46,22 @@ class JWTAuthenticatorFactory implements SecurityFactoryInterface, Authenticator
      */
     public function addConfiguration(NodeDefinition $node)
     {
-        // no-op - no config here for now
+        $node
+            ->children()
+                ->scalarNode('authenticator')
+                    ->defaultValue('lexik_jwt_authentication.security.jwt_authenticator')
+                ->end()
+            ->end()
+        ;
     }
 
     public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId)
     {
         $authenticatorId = 'security.authenticator.jwt.'.$firewallName;
         $container
-            ->setDefinition($authenticatorId, new ChildDefinition('lexik_jwt_authentication.security.jwt_authenticator'))
-            ->replaceArgument(3, new Reference($userProviderId));
+            ->setDefinition($authenticatorId, new ChildDefinition($config['authenticator']))
+            ->replaceArgument(3, new Reference($userProviderId))
+        ;
 
         // Compile-time parameter removed by RemoveLegacyAuthenticatorPass
         // Stop setting it when guard support gets removed (aka when removing Symfony<5.3 support)

--- a/Resources/doc/6-extending-jwt-authenticator.md
+++ b/Resources/doc/6-extending-jwt-authenticator.md
@@ -1,9 +1,9 @@
-Extending JWTTokenAuthenticator
+Extending JWTAuthenticator
 ===============================
 
-The `JWTTokenAuthenticator` class is responsible of authenticating JWT tokens. It is used through the `lexik_jwt_authentication.security.guard.jwt_token_authenticator` abstract service which can be customized in the most flexible but still structured way to do it: _creating your own authenticators by extending the service_, so you can manage various security contexts in the same application.
+The `JWTAuthenticator` class is responsible of authenticating JWT tokens. It is used through the `lexik_jwt_authentication.security.jwt_authenticator` abstract service which can be customized in the most flexible but still structured way to do it: _creating your own authenticators by extending the service_, so you can manage various security contexts in the same application.
 
-Creating your own Token Authenticator
+Creating your own Authenticator
 -------------------------------------
 
 The following code can be used for creating your own authenticators.
@@ -11,11 +11,11 @@ The following code can be used for creating your own authenticators.
 Create the authenticator class extending the built-in one:
 
 ```php
-namespace App\Security\Guard;
+namespace App\Security;
 
-use Lexik\Bundle\JWTAuthenticationBundle\Security\Guard\JWTTokenAuthenticator as BaseAuthenticator;
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator;
 
-class JWTTokenAuthenticator extends BaseAuthenticator
+class CustomAuthenticator extends JWTAuthenticator
 {
     // Your own logic
 }
@@ -26,9 +26,9 @@ Same for the service definition:
 ```yaml
 # config/services.yaml
 services:
-    app.jwt_token_authenticator:
-        class: App\Security\Guard\JWTTokenAuthenticator
-        parent: lexik_jwt_authentication.security.guard.jwt_token_authenticator
+    app.custom_authenticator:
+        class: App\Security\CustomAuthenticator
+        parent: lexik_jwt_authentication.security.jwt_authenticator
 ```
 
 Then, use it in your security configuration:
@@ -42,9 +42,8 @@ security:
         api:
             pattern:   ^/api
             stateless: true
-            guard: 
-                authenticators:
-                    - app.jwt_token_authenticator
+            jwt: 
+                authenticator: app.custom_authenticator
 
 ```
 
@@ -53,19 +52,19 @@ __Note:__ The code examples of this section require to have this step done, it m
 Using different Token Extractors per Authenticator
 --------------------------------------------------
 
-Token extractors are set up in the main configuration of this bundle, usually found in your `app/config/config.yml`.  
-If your application contains multiple firewalls with different security contexts, you may want to configure the different token extractors which should be used on each firewall respectively. This can be done by having as much authenticators as firewalls (for creating authenticators, see [the first section of this topic](#creating-your-own-token-authenticator)).
+Token extractors are set up in the main configuration of this bundle (see [configuration reference](1-configuration-reference.md#full-default-configuration)).
+If your application contains multiple firewalls with different security contexts, you may want to configure the different token extractors which should be used on each firewall respectively. This can be done by having as much authenticators as firewalls (for creating authenticators, see [the first section of this topic](#creating-your-own-authenticator)).
 
 
 ```php
-namespace App\Security\Guard;
+namespace App\Security;
 
-use Lexik\Bundle\JWTAuthenticationBundle\Security\Guard\JWTTokenAuthenticator as BaseAuthenticator;
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator;
 use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor;
 
-class JWTTokenAuthenticator extends BaseAuthenticator
+class CustomAuthenticator extends JWTAuthenticator
 {
-    /**
+     /**
      * @return TokenExtractor\TokenExtractorInterface
      */
     protected function getTokenExtractor()

--- a/Security/Authenticator/JWTAuthenticator.php
+++ b/Security/Authenticator/JWTAuthenticator.php
@@ -157,6 +157,30 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
     }
 
     /**
+     * Gets the jwt manager.
+     */
+    protected function getJwtManager(): JWTTokenManagerInterface
+    {
+        return $this->jwtManager;
+    }
+
+    /**
+     * Gets the event dispatcher.
+     */
+    protected function getEventDispatcher(): EventDispatcherInterface
+    {
+        return $this->eventDispatcher;
+    }
+
+    /**
+     * Gets the user provider.
+     */
+    protected function getUserProvider(): UserProviderInterface
+    {
+        return $this->userProvider;
+    }
+
+    /**
      * Loads the user to authenticate.
      *
      * @param array                 $payload      The token payload


### PR DESCRIPTION
Fix #915 

This PR will allow user to use their own custom authenticator that is extends from JWTAuthenticator.

Currently allow one authenticator per firewall only.

```php
namespace App\Security;

use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator;

class CustomAuthenticator extends JWTAuthenticator
{
    // Your own logic
}
```

```yaml
# config/services.yaml
services:
    app.custom_authenticator:
        class: App\Security\CustomAuthenticator
        parent: lexik_jwt_authentication.security.jwt_authenticator
```


```yaml
# config/packages/security.yaml
security:
    # ...
    firewalls:
        # ...
        api:
            pattern:   ^/api
            stateless: true
            jwt: 
                authenticator: app.custom_authenticator

```