### PR TITLE
Fix error when trying to decode token using new authenticator system

### DIFF
--- a/Security/Authenticator/Token/JWTPostAuthenticationToken.php
+++ b/Security/Authenticator/Token/JWTPostAuthenticationToken.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\Token;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+
+class JWTPostAuthenticationToken extends PostAuthenticationToken
+{
+    private $token;
+
+    public function __construct(UserInterface $user, string $firewallName, array $roles, string $token)
+    {
+        parent::__construct($user, $firewallName, $roles);
+
+        $this->token = $token;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCredentials(): string
+    {
+        return $this->token;
+    }
+}


### PR DESCRIPTION
If you are using new authenticator system, you cannot decode the token in a service or controller using `$jwtManager->decode($token->getToken());` because the Token Class `getCredentials()` return empty array instead of token.

Now i'm not sure about the `public function createToken(Passport $passport, string $firewallName): TokenInterface` in JwtAuthenticator. Do i need to adjust that one as well?

Anyways, this Fix #921.