### PR TITLE
Add 3 new getter method to JWTTokenAuthenticator

### DIFF
--- a/Security/Guard/JWTTokenAuthenticator.php
+++ b/Security/Guard/JWTTokenAuthenticator.php
@@ -250,6 +250,30 @@ class JWTTokenAuthenticator implements AuthenticatorInterface
     }
 
     /**
+     * @return JWTTokenManagerInterface
+     */
+    protected function getJwtManager()
+    {
+        return $this->jwtManager;
+    }
+
+    /**
+     * @return EventDispatcherInterface
+     */
+    protected function getDispatcher()
+    {
+        return $this->dispatcher;
+    }
+
+    /**
+     * @return TokenStorageInterface
+     */
+    protected function getPreAuthenticationTokenStorage()
+    {
+        return $this->preAuthenticationTokenStorage;
+    }
+
+    /**
      * Loads the user to authenticate.
      *
      * @param UserProviderInterface $userProvider An user provider


### PR DESCRIPTION
Fix #782 and #743

Add 3 new getter method for easy to reusing them in any child class. We don't have to explicit rewrite the same properties as parent class in custom guard authenticator anymore.