### PR TITLE
Allow to set provider in jwt authenticator.

### DIFF
--- a/DependencyInjection/Security/Factory/JWTAuthenticatorFactory.php
+++ b/DependencyInjection/Security/Factory/JWTAuthenticatorFactory.php
@@ -48,6 +48,9 @@ class JWTAuthenticatorFactory implements SecurityFactoryInterface, Authenticator
     {
         $node
             ->children()
+                ->scalarNode('provider')
+                    ->defaultNull()
+                ->end()
                 ->scalarNode('authenticator')
                     ->defaultValue('lexik_jwt_authentication.security.jwt_authenticator')
                 ->end()
@@ -58,6 +61,9 @@ class JWTAuthenticatorFactory implements SecurityFactoryInterface, Authenticator
     public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId)
     {
         $authenticatorId = 'security.authenticator.jwt.'.$firewallName;
+        
+        $userProviderId = empty($config['provider']) ? $userProviderId : 'security.user.provider.concrete.' . $config['provider'];
+
         $container
             ->setDefinition($authenticatorId, new ChildDefinition($config['authenticator']))
             ->replaceArgument(3, new Reference($userProviderId))

--- a/Resources/doc/1-configuration-reference.md
+++ b/Resources/doc/1-configuration-reference.md
@@ -160,7 +160,13 @@ security:
         api:
             # ...
             jwt: ~ # enables the jwt authenticator
+
+        # Full config with defaults:
+        #    jwt:
+        #        provider: null  (you can put provider here or just ignore this config)
+        #        authenticator: lexik_jwt_authentication.security.jwt_authenticator (default jwt authenticator)
         # ...
+
 ```
 
 For Symfony versions prior to 5.3, use the Guard authenticator:


### PR DESCRIPTION
Fix #892 

Allow to set provider in `jwt` authenticator.