### PR TITLE
Fix: Only attempt split_cookie extraction if all of the cookies are present

### DIFF
--- a/Tests/TokenExtractor/SplitCookieTokenExtractorTest.php
+++ b/Tests/TokenExtractor/SplitCookieTokenExtractorTest.php
@@ -21,6 +21,10 @@ class SplitCookieTokenExtractorTest extends TestCase
         $this->assertFalse($extractor->extract($request));
 
         $request = new Request();
+        $request->cookies->add(['jwt_s' => 'testsignature']);
+        $this->assertFalse($extractor->extract($request));
+
+        $request = new Request();
         $request->cookies->add(['jwt_hp' => 'testheader.testpayload']);
         $request->cookies->add(['jwt_s' => 'testsignature']);
         $this->assertEquals('testheader.testpayload.testsignature', $extractor->extract($request));

--- a/TokenExtractor/SplitCookieExtractor.php
+++ b/TokenExtractor/SplitCookieExtractor.php
@@ -35,7 +35,7 @@ class SplitCookieExtractor implements TokenExtractorInterface
             $jwtCookies[] = $request->cookies->get($cookie, false);
         }
 
-        if (empty(array_filter($jwtCookies))) {
+        if (count($this->cookies) !== count(array_filter($jwtCookies))) {
             return false;
         }
 


### PR DESCRIPTION
Fixes #930 

As explained in #930, this isn't a breaking change, because setups with partial cookies couldn't have made sense for anyone before. Some examples:
* **2 cookies `jwt_hp` and `jwt_s`, first one missing**: Will result in `.eySignature`, which is not a valid JWT token (note the leading period)
* **2 cookies `jwt_hp` and `jwt_s`, second one missing**: Will result in `eyHeader.eyPayload.` which is not a valid JWT token (note the trailing period)
* **2 cookies `jwt_complete` and `optional_suffix`, second one missing**: Will result in `eyHeader.eyPayload.eySignature.` which is not a valid JWT token (note the trailing period)
* **3 cookies `jwt_h`, `jwt_p` and `jwt_s`, middle one missing**: Will result in `eyHeader..eySignature` which is not a valid JWT token (note the two consecutive periods)

So up until now, there is no way someone was successfully using the SplitCookieExtractor with only some of the cookies present.