### PR TITLE
Symfony 6 Compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         continue-on-error: ${{ matrix.can-fail }}
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 include:
                     # Lowest Deps
@@ -27,23 +27,23 @@ jobs:
                       symfony: 4.4.*
                       composer-flags: '--prefer-stable'
                       can-fail: false
+                    # Development Symfony branches
                     - php: 7.3
-                      symfony: 5.3.*
-                      composer-flags: '--prefer-stable'
+                      symfony: 5.4.*@dev
+                      composer-flags: '--prefer-stable' # Needed to force `lcobucci/jwt` to install a usable version
                       can-fail: false
                     - php: 7.4
-                      symfony: 5.3.*
-                      composer-flags: '--prefer-stable'
+                      symfony: 5.4.*@dev
+                      composer-flags: ''
                       can-fail: false
-                    - php: 8.0
-                      symfony: 5.3.*
-                      composer-flags: '--prefer-stable'
-                      can-fail: false
-                    # Development Symfony branches
                     - php: 8.0
                       symfony: 5.4.*@dev
                       composer-flags: ''
-                      can-fail: true
+                      can-fail: false
+                    - php: 8.0
+                      symfony: 6.0.*@dev
+                      composer-flags: ''
+                      can-fail: false
 
         name: "PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }}${{ matrix.composer-flags != '' && format(' - Composer {0}', matrix.composer-flags) || '' }}"
 
@@ -65,6 +65,14 @@ jobs:
               with:
                   php-version: "${{ matrix.php }}"
                   tools: "composer:v2,flex"
+
+            - name: "Set Composer stability"
+              if: "matrix.symfony == '5.4.*@dev' || matrix.symfony == '6.0.*@dev'"
+              run: "composer config minimum-stability dev"
+
+            - name: "Remove symfony/security-guard"
+              if: "matrix.symfony == '6.0.*@dev'"
+              run: "composer remove --dev --no-update symfony/security-guard"
 
             - name: "Install dependencies"
               run: "composer update ${{ matrix.composer-flags }} --prefer-dist"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,148 +5,71 @@ on:
     push:
 
 jobs:
-    php-71:
-        name: PHP 7.1 / Symfony 4.4
+    tests:
         runs-on: ubuntu-latest
+        continue-on-error: ${{ matrix.can-fail }}
+        strategy:
+            fail-fast: true
+            matrix:
+                include:
+                    # Lowest Deps
+                    - php: 7.1
+                      symfony: 4.4.*
+                      composer-flags: '--prefer-stable --prefer-lowest'
+                      can-fail: false
+                    # LTS with latest stable PHP
+                    - php: 8.0
+                      symfony: 4.4.*
+                      composer-flags: '--prefer-stable'
+                      can-fail: false
+                    # Stable Symfony branches
+                    - php: 7.2
+                      symfony: 4.4.*
+                      composer-flags: '--prefer-stable'
+                      can-fail: false
+                    - php: 7.3
+                      symfony: 5.3.*
+                      composer-flags: '--prefer-stable'
+                      can-fail: false
+                    - php: 7.4
+                      symfony: 5.3.*
+                      composer-flags: '--prefer-stable'
+                      can-fail: false
+                    - php: 8.0
+                      symfony: 5.3.*
+                      composer-flags: '--prefer-stable'
+                      can-fail: false
+                    # Development Symfony branches
+                    - php: 8.0
+                      symfony: 5.4.*@dev
+                      composer-flags: ''
+                      can-fail: true
+
+        name: "PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }}${{ matrix.composer-flags != '' && format(' - Composer {0}', matrix.composer-flags) || '' }}"
+
         steps:
             - name: "Checkout"
               uses: "actions/checkout@v2"
               with:
                   fetch-depth: 2
+
+            - name: "Cache Composer packages"
+              uses: "actions/cache@v2"
+              with:
+                  path: "~/.composer/cache"
+                  key: "php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-composer-${{ hashFiles('composer.json') }}-flags-${{ matrix.composer-flags }}"
+                  restore-keys: "php-"
 
             - name: "Install PHP"
               uses: "shivammathur/setup-php@v2"
               with:
-                  php-version: "7.1"
+                  php-version: "${{ matrix.php }}"
+                  tools: "composer:v2,flex"
 
-            - name: "Cache composer packages"
-              uses: "actions/cache@v2"
-              with:
-                  path: "~/.composer/cache"
-                  key: "php-7.1-composer-locked-${{ hashFiles('composer.lock') }}"
-                  restore-keys: "php-7.1-composer-locked-"
-
-            - name: "Install Symfony 4.4"
-              run: "composer require symfony/symfony:4.4.* --no-update"
-
-            - name: "Install dependencies with composer"
-              run: "composer update --no-interaction"
-
-            - name: "Run PHPUnit Tests"
-              run: "composer test"
-    php-72:
-        name: PHP 7.2 / Symfony 5.1
-        runs-on: ubuntu-latest
-        steps:
-            - name: "Checkout"
-              uses: "actions/checkout@v2"
-              with:
-                  fetch-depth: 2
-
-            - name: "Install PHP 7.2"
-              uses: "shivammathur/setup-php@v2"
-              with:
-                  php-version: "7.2"
-
-            - name: "Cache composer packages"
-              uses: "actions/cache@v2"
-              with:
-                  path: "~/.composer/cache"
-                  key: "php-7.2-composer-locked-${{ hashFiles('composer.lock') }}"
-                  restore-keys: "php-7.2-composer-locked-"
-
-            - name: "Install Symfony 5.1"
-              run: "composer require symfony/symfony:5.1.* --no-update"
-
-            - name: "Install dependencies with composer"
-              run: "composer update --no-interaction"
-
-            - name: "Run PHPUnit Tests"
-              run: "composer test"
-    php-73:
-        name: PHP 7.3 / Symfony 5.2
-        runs-on: ubuntu-latest
-        steps:
-            - name: "Checkout"
-              uses: "actions/checkout@v2"
-              with:
-                  fetch-depth: 2
-
-            - name: "Install PHP 7.3"
-              uses: "shivammathur/setup-php@v2"
-              with:
-                  php-version: "7.3"
-
-            - name: "Cache composer packages"
-              uses: "actions/cache@v2"
-              with:
-                  path: "~/.composer/cache"
-                  key: "php-7.3-composer-locked-${{ hashFiles('composer.lock') }}"
-                  restore-keys: "php-7.3-composer-locked-"
-
-            - name: "Install Symfony 5.2"
-              run: "composer require symfony/symfony:5.2.* --no-update"
-
-            - name: "Install dependencies with composer"
-              run: "composer update --no-interaction"
-
-            - name: "Run PHPUnit Tests"
-              run: "composer test"
-    php-74:
-        name: PHP 7.4 / Symfony 5.3
-        runs-on: ubuntu-latest
-        steps:
-            - name: "Checkout"
-              uses: "actions/checkout@v2"
-              with:
-                  fetch-depth: 2
-
-            - name: "Install PHP 7.4"
-              uses: "shivammathur/setup-php@v2"
-              with:
-                  php-version: "7.4"
-
-            - name: "Cache composer packages"
-              uses: "actions/cache@v2"
-              with:
-                  path: "~/.composer/cache"
-                  key: "php-7.4-composer-locked-${{ hashFiles('composer.lock') }}"
-                  restore-keys: "php-7.4-composer-locked-"
-
-            - name: "Install Symfony 5.3"
-              run: "composer require symfony/symfony:5.3.* --no-update"
-
-            - name: "Install dependencies with composer"
-              run: "composer update --no-interaction"
-
-            - name: "Run PHPUnit Tests"
-              run: "composer test"
-    php8:
-        name: PHP 8 / Symfony 5.4@dev
-        runs-on: ubuntu-latest
-        steps:
-            - name: "Checkout"
-              uses: "actions/checkout@v2"
-              with:
-                  fetch-depth: 2
-
-            - name: "Install PHP 8"
-              uses: "shivammathur/setup-php@v2"
-              with:
-                  php-version: "8"
-
-            - name: "Cache composer packages"
-              uses: "actions/cache@v2"
-              with:
-                  path: "~/.composer/cache"
-                  key: "php-8-composer-locked-${{ hashFiles('composer.lock') }}"
-                  restore-keys: "php-8-composer-locked-"
-
-            - name: "Install Symfony 5.4"
-              run: "composer require symfony/symfony:5.4.*@dev --no-update"
-
-            - name: "Install dependencies with composer"
-              run: "composer update --no-interaction"
+            - name: "Install dependencies"
+              run: "composer update ${{ matrix.composer-flags }} --prefer-dist"
+              env:
+                SYMFONY_REQUIRE: "${{ matrix.symfony }}"
 
             - name: "Run PHPUnit Tests"
               run: "composer test"

--- a/Command/CheckConfigCommand.php
+++ b/Command/CheckConfigCommand.php
@@ -40,6 +40,8 @@ class CheckConfigCommand extends Command
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/Command/GenerateTokenCommand.php
+++ b/Command/GenerateTokenCommand.php
@@ -47,6 +47,8 @@ class GenerateTokenCommand extends Command
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('lexik_jwt_authentication');
 

--- a/DependencyInjection/Security/Factory/JWTAuthenticatorFactory.php
+++ b/DependencyInjection/Security/Factory/JWTAuthenticatorFactory.php
@@ -2,9 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory;
 
-use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
-use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -15,7 +13,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-class JWTAuthenticatorFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
+class JWTAuthenticatorFactory implements AuthenticatorFactoryInterface
 {
     /**
      * @throws \LogicException
@@ -28,15 +26,15 @@ class JWTAuthenticatorFactory implements SecurityFactoryInterface, Authenticator
     /**
      * {@inheritdoc}
      */
-    public function getPosition()
+    public function getPriority(): int
     {
-        return 'pre_auth';
+        return -10;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getKey()
+    public function getKey(): string
     {
         return 'jwt';
     }
@@ -55,7 +53,7 @@ class JWTAuthenticatorFactory implements SecurityFactoryInterface, Authenticator
         ;
     }
 
-    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId)
+    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId): string
     {
         $authenticatorId = 'security.authenticator.jwt.'.$firewallName;
         $container

--- a/DependencyInjection/Security/Factory/JWTFactory.php
+++ b/DependencyInjection/Security/Factory/JWTFactory.php
@@ -28,6 +28,8 @@ class JWTFactory implements SecurityFactoryInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
     public function create(ContainerBuilder $container, $id, $config, $userProvider, $defaultEntryPoint)
     {
@@ -86,6 +88,8 @@ class JWTFactory implements SecurityFactoryInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getPosition()
     {
@@ -94,6 +98,8 @@ class JWTFactory implements SecurityFactoryInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getKey()
     {

--- a/Exception/ExpiredTokenException.php
+++ b/Exception/ExpiredTokenException.php
@@ -14,6 +14,8 @@ class ExpiredTokenException extends AuthenticationException
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getMessageKey()
     {

--- a/Exception/InvalidPayloadException.php
+++ b/Exception/InvalidPayloadException.php
@@ -23,6 +23,8 @@ class InvalidPayloadException extends AuthenticationException
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getMessageKey()
     {

--- a/Exception/InvalidTokenException.php
+++ b/Exception/InvalidTokenException.php
@@ -13,6 +13,8 @@ class InvalidTokenException extends AuthenticationException
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getMessageKey()
     {

--- a/Exception/MissingTokenException.php
+++ b/Exception/MissingTokenException.php
@@ -13,6 +13,8 @@ class MissingTokenException extends AuthenticationException
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getMessageKey()
     {

--- a/LexikJWTAuthenticationBundle.php
+++ b/LexikJWTAuthenticationBundle.php
@@ -7,6 +7,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Compiler\RegisterLe
 use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Compiler\WireGenerateTokenCommandPass;
 use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory\JWTAuthenticatorFactory;
 use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory\JWTFactory;
+use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory\JWTSecurityFactory;
 use Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory\JWTUserFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
@@ -35,9 +36,15 @@ class LexikJWTAuthenticationBundle extends Bundle
         $extension = $container->getExtension('security');
 
         $extension->addUserProviderFactory(new JWTUserFactory());
-        $extension->addSecurityListenerFactory(new JWTFactory(false)); // BC 1.x, to be removed in 3.0
-        if (interface_exists(AuthenticatorFactoryInterface::class)) {
-            $extension->addSecurityListenerFactory(new JWTAuthenticatorFactory());
+
+        // Authenticator factory for Symfony 5.4 and later
+        if (method_exists($extension, 'addAuthenticatorFactory')) {
+            $extension->addAuthenticatorFactory(new JWTAuthenticatorFactory());
+        }
+
+        // Security listener factory for Symfony 5.4 and earlier
+        if (method_exists($extension, 'addSecurityListenerFactory')) {
+            $extension->addSecurityListenerFactory(new JWTFactory(false)); // BC 1.x, to be removed in 3.0
         }
     }
 

--- a/Response/JWTAuthenticationFailureResponse.php
+++ b/Response/JWTAuthenticationFailureResponse.php
@@ -4,6 +4,54 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Response;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
 
+if (80000 <= \PHP_VERSION_ID && (new \ReflectionMethod(JsonResponse::class, 'setData'))->hasReturnType()) {
+    eval('
+        namespace Lexik\Bundle\JWTAuthenticationBundle\Response;
+
+        use Symfony\Component\HttpFoundation\JsonResponse;
+
+        /**
+         * Compatibility layer for Symfony 6.0 and later.
+         *
+         * @internal
+         */
+        abstract class JWTCompatAuthenticationFailureResponse extends JsonResponse
+        {
+            /**
+             * Sets the response data with the statusCode & message included.
+             *
+             * {@inheritdoc}
+             *
+             * @return static
+             */
+            public function setData($data = []): static
+            {
+                return parent::setData((array) $data + ["code" => $this->statusCode, "message" => $this->getMessage()]);
+            }
+        }
+    ');
+} else {
+    /**
+     * Compatibility layer for Symfony 5.4 and earlier.
+     *
+     * @internal
+     */
+    abstract class JWTCompatAuthenticationFailureResponse extends JsonResponse
+    {
+        /**
+         * Sets the response data with the statusCode & message included.
+         *
+         * {@inheritdoc}
+         *
+         * @return static
+         */
+        public function setData($data = [])
+        {
+            return parent::setData((array) $data + ['code' => $this->statusCode, 'message' => $this->getMessage()]);
+        }
+    }
+}
+
 /**
  * JWTAuthenticationFailureResponse.
  *
@@ -11,7 +59,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-final class JWTAuthenticationFailureResponse extends JsonResponse
+final class JWTAuthenticationFailureResponse extends JWTCompatAuthenticationFailureResponse
 {
     private $message;
 
@@ -46,15 +94,5 @@ final class JWTAuthenticationFailureResponse extends JsonResponse
     public function getMessage()
     {
         return $this->message;
-    }
-
-    /**
-     * Sets the response data with the statusCode & message included.
-     *
-     * {@inheritdoc}
-     */
-    public function setData($data = [])
-    {
-        parent::setData((array) $data + ['code' => $this->statusCode, 'message' => $this->message]);
     }
 }

--- a/Security/Authentication/Token/JWTUserToken.php
+++ b/Security/Authentication/Token/JWTUserToken.php
@@ -6,12 +6,26 @@ use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
 
+if (interface_exists(GuardTokenInterface::class)) {
+    /**
+     * Compatibility layer ensuring the guard token interface is applied when available.
+     *
+     * @internal
+     */
+    abstract class JWTCompatUserToken extends AbstractToken implements GuardTokenInterface {}
+} else {
+    /**
+     * @internal
+     */
+    abstract class JWTCompatUserToken extends AbstractToken {}
+}
+
 /**
  * JWTUserToken.
  *
  * @author Nicolas Cabot <n.cabot@lexik.fr>
  */
-class JWTUserToken extends AbstractToken implements GuardTokenInterface
+class JWTUserToken extends JWTCompatUserToken
 {
     /**
      * @var string
@@ -35,7 +49,10 @@ class JWTUserToken extends AbstractToken implements GuardTokenInterface
         }
 
         $this->setRawToken($rawToken);
-        $this->setAuthenticated(true);
+
+        if (method_exists($this, 'setAuthenticated')) {
+            $this->setAuthenticated(true);
+        }
 
         $this->providerKey = $firewallName;
     }

--- a/Security/Authenticator/JWTAuthenticator.php
+++ b/Security/Authenticator/JWTAuthenticator.php
@@ -88,7 +88,10 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
         return false !== $this->getTokenExtractor()->extract($request);
     }
 
-    public function authenticate(Request $request): PassportInterface
+    /**
+     * @return Passport
+     */
+    public function authenticate(Request $request) /*: Passport */
     {
         $token = $this->getTokenExtractor()->extract($request);
 
@@ -238,9 +241,9 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
         if (!$passport instanceof SelfValidatingPassport) {
             throw new \LogicException(sprintf('Expected "%s" but got "%s".', SelfValidatingPassport::class, get_debug_type($passport)));
         }
-        
+
         $token = new JWTPostAuthenticationToken($passport->getUser(), $firewallName, $passport->getUser()->getRoles(), $passport->getAttribute('token'));
-        
+
         $this->eventDispatcher->dispatch(new JWTAuthenticatedEvent($passport->getAttribute('payload'), $token), Events::JWT_AUTHENTICATED);
 
         return $token;
@@ -251,7 +254,7 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
         if (!$passport instanceof SelfValidatingPassport) {
             throw new \LogicException(sprintf('Expected "%s" but got "%s".', SelfValidatingPassport::class, get_debug_type($passport)));
         }
-        
+
         $token = new JWTPostAuthenticationToken($passport->getUser(), $firewallName, $passport->getUser()->getRoles(), $passport->getAttribute('token'));
 
         $this->eventDispatcher->dispatch(new JWTAuthenticatedEvent($passport->getAttribute('payload'), $token), Events::JWT_AUTHENTICATED);

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -31,7 +31,7 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
     /**
      * {@inheritdoc}
      */
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());
         $statusCode = self::mapExceptionCodeToStatusCode($exception->getCode());

--- a/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -8,6 +8,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationSuccessRespon
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Cookie\JWTCookieProvider;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
@@ -43,11 +44,14 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
     /**
      * {@inheritdoc}
      */
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token)
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response
     {
         return $this->handleAuthenticationSuccess($token->getUser());
     }
 
+    /**
+     * @return Response
+     */
     public function handleAuthenticationSuccess(UserInterface $user, $jwt = null)
     {
         if (null === $jwt) {

--- a/Security/User/JWTUserProvider.php
+++ b/Security/User/JWTUserProvider.php
@@ -27,6 +27,8 @@ final class JWTUserProvider implements PayloadAwareUserProviderInterface
      * {@inheritdoc}
      *
      * @param array $payload The JWT payload from which to create an instance
+     *
+     * @return UserInterface
      */
     public function loadUserByUsername($username, array $payload = [])
     {
@@ -51,7 +53,7 @@ final class JWTUserProvider implements PayloadAwareUserProviderInterface
         if (isset($this->cache[$username])) {
             return $this->cache[$username];
         }
-        
+
         $class = $this->class;
 
         return $this->cache[$username] = $class::createFromPayload($username, $payload);
@@ -62,16 +64,16 @@ final class JWTUserProvider implements PayloadAwareUserProviderInterface
         if (isset($this->cache[$userIdentifier])) {
             return $this->cache[$userIdentifier];
         }
-        
+
         $class = $this->class;
-        
+
         return $this->cache[$userIdentifier] = $class::createFromPayload($userIdentifier, $payload);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function supportsClass($class)
+    public function supportsClass($class): bool
     {
         return $class === $this->class || (new \ReflectionClass($class))->implementsInterface(JWTUserInterface::class);
     }

--- a/Tests/Functional/Bundle/Bundle.php
+++ b/Tests/Functional/Bundle/Bundle.php
@@ -3,11 +3,12 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\Bundle;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\Bundle\DependencyInjection\BundleExtension;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle as BaseBundle;
 
 class Bundle extends BaseBundle
 {
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new BundleExtension();
     }

--- a/Tests/Functional/ForwardCompatTestCaseTrait.php
+++ b/Tests/Functional/ForwardCompatTestCaseTrait.php
@@ -2,44 +2,19 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-
-if (70000 <= \PHP_VERSION_ID && (new \ReflectionMethod(WebTestCase::class, 'tearDown'))->hasReturnType()) {
-    eval('
-        namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional;
-
-        /**
-         * @internal
-         */
-        trait ForwardCompatTestCaseTrait
-        {
-            protected function tearDown(): void
-            {
-                static::ensureKernelShutdown();
-                static::$kernel = null;
-            }
-            
-            protected function setUp(): void
-            {
-                $this->doSetUp();
-            }
-        }
-    ');
-} else {
-    /**
-     * @internal
-     */
-    trait ForwardCompatTestCaseTrait
+/**
+ * @internal
+ */
+trait ForwardCompatTestCaseTrait
+{
+    protected function tearDown(): void
     {
-        protected function tearDown()
-        {
-            static::ensureKernelShutdown();
-            static::$kernel = null;
-        }
+        static::ensureKernelShutdown();
+        static::$kernel = null;
+    }
 
-        protected function setUp()
-        {
-            $this->doSetUp();
-        }
+    protected function setUp(): void
+    {
+        $this->doSetUp();
     }
 }

--- a/Tests/Functional/TestCase.php
+++ b/Tests/Functional/TestCase.php
@@ -4,6 +4,7 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * TestCase.
@@ -17,11 +18,11 @@ abstract class TestCase extends WebTestCase
     /**
      * {@inheritdoc}
      */
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         require_once __DIR__.'/app/AppKernel.php';
 
-        return new AppKernel('test', true, isset($options['test_case']) ? $options['test_case'] : null);
+        return new AppKernel('test', true, $options['test_case'] ?? null);
     }
 
     protected static function createAuthenticatedClient($token = null)

--- a/Tests/Functional/Utils/CallableEventSubscriber.php
+++ b/Tests/Functional/Utils/CallableEventSubscriber.php
@@ -27,7 +27,7 @@ class CallableEventSubscriber implements EventSubscriberInterface
         Events::JWT_EXPIRED => JWTExpiredEvent::class,
     ];
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         $subscriberMap = [];
 

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -35,7 +35,7 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
@@ -53,7 +53,7 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir().'/LexikJWTAuthenticationBundle/cache';
     }
@@ -61,7 +61,7 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return sys_get_temp_dir().'/LexikJWTAuthenticationBundle/logs';
     }

--- a/Tests/Functional/app/config/base_security.yml
+++ b/Tests/Functional/app/config/base_security.yml
@@ -9,7 +9,3 @@ security:
         jwt:
             lexik_jwt:
                 class: Lexik\Bundle\JWTAuthenticationBundle\Tests\Stubs\JWTUser
-
-    access_control:
-        - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }

--- a/Tests/Functional/app/config/security_in_memory.yml
+++ b/Tests/Functional/app/config/security_in_memory.yml
@@ -21,6 +21,10 @@ security:
         api:
             pattern:  ^/api
             stateless: true
-            anonymous: false
+            lazy: true
             provider: in_memory
             jwt: ~
+
+    access_control:
+      - { path: ^/login, roles: PUBLIC_ACCESS }
+      - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }

--- a/Tests/Functional/app/config/security_in_memory_legacy.yml
+++ b/Tests/Functional/app/config/security_in_memory_legacy.yml
@@ -25,3 +25,7 @@ security:
             guard:
                 authenticators:
                     - lexik_jwt_authentication.jwt_token_authenticator
+
+    access_control:
+        - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }

--- a/Tests/Functional/app/config/security_lexik_jwt.yml
+++ b/Tests/Functional/app/config/security_lexik_jwt.yml
@@ -23,3 +23,7 @@ security:
             stateless: true
             provider: jwt
             jwt: ~
+
+    access_control:
+      - { path: ^/login, roles: PUBLIC_ACCESS }
+      - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }

--- a/Tests/Functional/app/config/security_lexik_jwt_legacy.yml
+++ b/Tests/Functional/app/config/security_lexik_jwt_legacy.yml
@@ -25,3 +25,7 @@ security:
             guard:
                 authenticators:
                     - lexik_jwt_authentication.jwt_token_authenticator
+
+    access_control:
+        - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }

--- a/Tests/Security/Authentication/Firewall/JWTListenerTest.php
+++ b/Tests/Security/Authentication/Firewall/JWTListenerTest.php
@@ -9,6 +9,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureRespon
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Firewall\JWTListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
@@ -21,6 +22,13 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class JWTListenerTest extends TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        if (!interface_exists(AuthenticationManagerInterface::class)) {
+            self::markTestSkipped('Test only applies to symfony/security-core 5.4 and earlier');
+        }
+    }
+
     /**
      * @group time-sensitive
      */
@@ -84,7 +92,7 @@ class JWTListenerTest extends TestCase
     public function getAuthenticationManagerMock()
     {
         return $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')
+            ->getMockBuilder(AuthenticationManagerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/Security/Authentication/Provider/JWTProviderTest.php
+++ b/Tests/Security/Authentication/Provider/JWTProviderTest.php
@@ -2,13 +2,20 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Security\Authentication\Provider;
 
+use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Provider\JWTProvider;
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * JWTProviderTest.
@@ -19,6 +26,13 @@ use Symfony\Component\Security\Core\User\InMemoryUserProvider;
  */
 class JWTProviderTest extends TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        if (!interface_exists(AuthenticationProviderInterface::class)) {
+            self::markTestSkipped('Test only applies to symfony/security-core 5.4 and earlier');
+        }
+    }
+
     /**
      * test supports method.
      */
@@ -28,7 +42,7 @@ class JWTProviderTest extends TestCase
 
         /** @var TokenInterface $usernamePasswordToken */
         $usernamePasswordToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')
+            ->getMockBuilder(UsernamePasswordToken::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -36,7 +50,7 @@ class JWTProviderTest extends TestCase
 
         /** @var TokenInterface $jwtUserToken */
         $jwtUserToken = $this
-            ->getMockBuilder('Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken')
+            ->getMockBuilder(JWTUserToken::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -50,7 +64,7 @@ class JWTProviderTest extends TestCase
 
         /** @var TokenInterface $jwtUserToken */
         $jwtUserToken = $this
-            ->getMockBuilder('Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken')
+            ->getMockBuilder(JWTUserToken::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -71,7 +85,7 @@ class JWTProviderTest extends TestCase
 
         /** @var TokenInterface $jwtUserToken */
         $jwtUserToken = $this
-            ->getMockBuilder('Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken')
+            ->getMockBuilder(JWTUserToken::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -95,7 +109,7 @@ class JWTProviderTest extends TestCase
 
         /** @var TokenInterface $jwtUserToken */
         $jwtUserToken = $this
-            ->getMockBuilder('Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken')
+            ->getMockBuilder(JWTUserToken::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -118,12 +132,12 @@ class JWTProviderTest extends TestCase
     {
         /** @var TokenInterface $jwtUserToken */
         $jwtUserToken = $this
-            ->getMockBuilder('Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken')
+            ->getMockBuilder(JWTUserToken::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $user = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')
+            ->getMockBuilder(UserInterface::class)
             ->getMock();
 
         $user->expects($this->any())->method('getRoles')->will($this->returnValue([]));
@@ -139,7 +153,7 @@ class JWTProviderTest extends TestCase
         $provider = new JWTProvider($userProvider, $jwtManager, $eventDispatcher, 'username');
 
         $this->assertInstanceOf(
-            'Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken',
+            JWTUserToken::class,
             $provider->authenticate($jwtUserToken)
         );
 
@@ -152,7 +166,7 @@ class JWTProviderTest extends TestCase
         $provider->setUserIdentityField('uid');
 
         $this->assertInstanceOf(
-            'Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken',
+            JWTUserToken::class,
             $provider->authenticate($jwtUserToken)
         );
     }
@@ -162,7 +176,7 @@ class JWTProviderTest extends TestCase
      */
     protected function getJWTManagerMock()
     {
-        return $this->getMockBuilder('Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager')
+        return $this->getMockBuilder(JWTManager::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -172,7 +186,7 @@ class JWTProviderTest extends TestCase
      */
     protected function getJWTEncoderMock()
     {
-        return $this->getMockBuilder('Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface')
+        return $this->getMockBuilder(JWTEncoderInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -182,7 +196,7 @@ class JWTProviderTest extends TestCase
      */
     protected function getUserProviderMock()
     {
-        return $this->getMockBuilder('Symfony\Component\Security\Core\User\InMemoryUserProvider')
+        return $this->getMockBuilder(InMemoryUserProvider::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -204,7 +218,7 @@ class JWTProviderTest extends TestCase
      */
     protected function getEventDispatcherMock()
     {
-        return $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
+        return $this->getMockBuilder(EventDispatcherInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/Security/Guard/JWTTokenAuthenticatorTest.php
+++ b/Tests/Security/Guard/JWTTokenAuthenticatorTest.php
@@ -11,7 +11,6 @@ use Lexik\Bundle\JWTAuthenticationBundle\Exception\InvalidPayloadException;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\InvalidTokenException;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\MissingTokenException;
-use Lexik\Bundle\JWTAuthenticationBundle\Exception\UserNotFoundException;
 use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureResponse;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\PreAuthenticationJWTUserToken;
@@ -26,6 +25,7 @@ use Symfony\Component\Security\Core\Exception\UserNotFoundException as SecurityU
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\AuthenticatorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -34,6 +34,13 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class JWTTokenAuthenticatorTest extends TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        if (!class_exists(AuthenticatorInterface::class)) {
+            self::markTestSkipped('Test only applies to symfony/security-guard 5.4 and earlier');
+        }
+    }
+
     public function testGetCredentials()
     {
         $jwtManager = $this->getJWTManagerMock();

--- a/Tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/Tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
@@ -2,13 +2,16 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Security\Http\Authentication;
 
+use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Cookie\JWTCookieProvider;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -114,7 +117,7 @@ class AuthenticationSuccessHandlerTest extends TestCase
     protected function getRequest()
     {
         $request = $this
-            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->getMockBuilder(Request::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -127,7 +130,7 @@ class AuthenticationSuccessHandlerTest extends TestCase
     protected function getToken()
     {
         $token = $this
-            ->getMockBuilder('Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken')
+            ->getMockBuilder(JWTUserToken::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -174,7 +177,7 @@ class AuthenticationSuccessHandlerTest extends TestCase
             ->expects($this->once())
             ->method('dispatch')
             ->with(
-                $this->isInstanceOf('Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent'),
+                $this->isInstanceOf(AuthenticationSuccessEvent::class),
                 $this->equalTo(Events::AUTHENTICATION_SUCCESS)
             );
 

--- a/Tests/Stubs/User.php
+++ b/Tests/Stubs/User.php
@@ -42,7 +42,7 @@ final class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function getRoles()
+    public function getRoles(): array
     {
         return $this->roles;
     }
@@ -50,7 +50,7 @@ final class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->password;
     }
@@ -58,14 +58,15 @@ final class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
+        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->getUserIdentifier();
     }

--- a/composer.json
+++ b/composer.json
@@ -37,21 +37,34 @@
         }
     ],
     "require": {
-        "namshi/jose": "^7.2",
         "php": ">=7.1",
         "ext-openssl": "*",
         "lcobucci/jwt": "^3.4|^4.0",
-        "symfony/framework-bundle": "^4.4|^5.1",
-        "symfony/security-bundle": "^4.4|^5.1",
-        "symfony/deprecation-contracts": "^2.4"
+        "namshi/jose": "^7.2",
+        "symfony/config": "^4.4|^5.4|^6.0",
+        "symfony/dependency-injection": "^4.4|^5.4|^6.0",
+        "symfony/deprecation-contracts": "^2.4",
+        "symfony/event-dispatcher": "^4.4|^5.4|^6.0",
+        "symfony/http-foundation": "^4.4|^5.4|^6.0",
+        "symfony/http-kernel": "^4.4|^5.4|^6.0",
+        "symfony/property-access": "^4.4|^5.4|^6.0",
+        "symfony/security-bundle": "^4.4|^5.4|^6.0",
+        "symfony/security-core": "^4.4|^5.4|^6.0",
+        "symfony/security-http": "^4.4|^5.4|^6.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "^4.4|^5.1",
-        "symfony/console": "^4.4|^5.1",
-        "symfony/dom-crawler": "^4.4|^5.1",
-        "symfony/phpunit-bridge": "^4.4|^5.1",
-        "symfony/var-dumper": "^4.4|^5.1",
-        "symfony/yaml": "^4.4|^5.1"
+        "symfony/browser-kit": "^4.4|^5.4|^6.0",
+        "symfony/console": "^4.4|^5.4|^6.0",
+        "symfony/dom-crawler": "^4.4|^5.4|^6.0",
+        "symfony/filesystem": "^4.4|^5.4|^6.0",
+        "symfony/framework-bundle": "^4.4|^5.4|^6.0",
+        "symfony/phpunit-bridge": "^4.4|^5.4|^6.0",
+        "symfony/security-guard": "^4.4|^5.4",
+        "symfony/var-dumper": "^4.4|^5.4|^6.0",
+        "symfony/yaml": "^4.4|^5.4|^6.0"
+    },
+    "conflict": {
+        "symfony/console": "<4.4"
     },
     "suggest": {
         "gesdinet/jwt-refresh-token-bundle": "Implements a refresh token system over Json Web Tokens in Symfony",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,6 @@
     </filter>
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"></env>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=27"></env>
     </php>
 </phpunit>


### PR DESCRIPTION
This is the work needed for Symfony 6 compatibility.  The gist of the changes are:

- Allow Symfony 6 install
- Tweak the GitHub actions config, the tested versions are now set in a matrix so there's only one build config instead of duplicating it for each build
- Drops Symfony 5.3 support, the return signature change in `Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface::authenticate()` between 5.3 and 5.4 is a bit tricky to deal with while keeping support for the non-LTS 5.3
- Updates `Lexik\Bundle\JWTAuthenticationBundle\DependencyInjection\Security\Factory\JWTAuthenticatorFactory` to address the security listener factory -> authenticator factory changes/deprecations in the SecurityBundle in 5.4
- Adds typehints or doc blocks as needed