### PR TITLE
Allowing session cookie (split cookie)

### DIFF
--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -103,7 +103,7 @@ class LexikJWTAuthenticationExtension extends Extension
                 $container
                     ->setDefinition($id = "lexik_jwt_authentication.cookie_provider.$name", new ChildDefinition('lexik_jwt_authentication.cookie_provider'))
                     ->replaceArgument(0, $name)
-                    ->replaceArgument(1, $attributes['lifetime'] ?: ($config['token_ttl'] ?: 0))
+                    ->replaceArgument(1, $attributes['lifetime'] ?? ($config['token_ttl'] ?: 0))
                     ->replaceArgument(2, $attributes['samesite'])
                     ->replaceArgument(3, $attributes['path'])
                     ->replaceArgument(4, $attributes['domain'])

--- a/Resources/doc/1-configuration-reference.md
+++ b/Resources/doc/1-configuration-reference.md
@@ -116,6 +116,8 @@ set_cookies:
 ### Automatically generating split cookies
 You are also able to automatically generate split cookies. Benefits of this approach are in [this post](https://medium.com/lightrail/getting-token-authentication-right-in-a-stateless-single-page-application-57d0c6474e3).
 
+Set the signature cookie (jwt_s) lifetime to 0 to create session cookies.
+
 Keep in mind, that SameSite attribute is **not supported** in [some browsers](https://caniuse.com/#feat=same-site-cookie-attribute)
 
 ```
@@ -138,7 +140,7 @@ set_cookies:
             - payload
 
     jwt_s:
-        lifetime: null
+        lifetime: 0
         samesite: strict
         path: /
         domain: null

--- a/Security/Http/Cookie/JWTCookieProvider.php
+++ b/Security/Http/Cookie/JWTCookieProvider.php
@@ -43,17 +43,21 @@ final class JWTCookieProvider
             throw new \LogicException(sprintf('The cookie name must be provided, either pass it as 2nd argument of %s or set a default name via the constructor.', __METHOD__));
         }
 
-        if (!$expiresAt && !$this->defaultLifetime) {
+        if (!$expiresAt && null === $this->defaultLifetime) {
             throw new \LogicException(sprintf('The cookie expiration time must be provided, either pass it as 3rd argument of %s or set a default lifetime via the constructor.', __METHOD__));
         }
 
         $jwtParts = new JWTSplitter($jwt);
         $jwt = $jwtParts->getParts($split ?: $this->defaultSplit);
 
+        if (null === $expiresAt) {
+            $expiresAt = 0 === $this->defaultLifetime ? 0 : (time() + $this->defaultLifetime);
+        }
+        
         return new Cookie(
             $name ?: $this->defaultName,
             $jwt,
-            null === $expiresAt ? (time() + $this->defaultLifetime) : $expiresAt,
+            $expiresAt,
             $path ?: $this->defaultPath,
             $domain ?: $this->defaultDomain,
             $secure ?: $this->defaultSecure,

--- a/Tests/Security/Http/Cookie/JWTCookieProviderTest.php
+++ b/Tests/Security/Http/Cookie/JWTCookieProviderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Security\Http\Cookie;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Cookie\JWTCookieProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * JWTCookieProviderTest.
+ */
+class JWTCookieProviderTest extends TestCase
+{
+    public function testCreateCookieWithExpiration()
+    {
+        $expiresAt = time() + 3600;
+        $cookieProvider = new JWTCookieProvider("default_name");
+        $cookie = $cookieProvider->createCookie("header.payload.signature", "name", $expiresAt);
+
+        $this->assertEquals($expiresAt, $cookie->getExpiresTime());
+    }
+
+    public function testCreateCookieWithLifetime()
+    {
+        $lifetime = 3600;
+        $cookieProvider = new JWTCookieProvider("default_name", $lifetime);
+        $cookie = $cookieProvider->createCookie("header.payload.signature");
+
+        $this->assertEquals(time() + $lifetime, $cookie->getExpiresTime());
+    }
+
+    public function testCreateSessionCookie()
+    {
+        $cookieProvider = new JWTCookieProvider("default_name", 0);
+        $cookie = $cookieProvider->createCookie("header.payload.signature");
+
+        $this->assertEquals(0, $cookie->getExpiresTime());
+    }
+}


### PR DESCRIPTION
AS described in #809, the split cookie approach cannot be fully implemented because this bundle doesn't allow session cookie (when lifetime=0, then the token ttl value was used instead). This pull request allows a 0 lifetime cookie:

lexik_jwt_authentication.yaml
```
lexik_jwt_authentication:
    secret_key: '%env(resolve:JWT_SECRET_KEY)%'
    public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
    pass_phrase: '%env(JWT_PASSPHRASE)%'
    token_ttl: 86400
    token_extractors:
        split_cookie:
            enabled: true
            cookies:
                - jwt_hp
                - jwt_s
    set_cookies:
        jwt_hp:
            lifetime: 360
            samesite: strict
            path: /
            domain: null
            httpOnly: false
            split:
                - header
                - payload

        jwt_s:
            lifetime: 0 # session cookie here
            samesite: strict
            path: /
            domain: null
            httpOnly: true
            split:
                - signature
```