### PR TITLE
Allow symfony/deprecations-contract v3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "namshi/jose": "^7.2",
         "symfony/config": "^4.4|^5.3|^6.0",
         "symfony/dependency-injection": "^4.4|^5.3|^6.0",
-        "symfony/deprecation-contracts": "^2.4",
+        "symfony/deprecation-contracts": "^2.4|^3.0",
         "symfony/event-dispatcher": "^4.4|^5.3|^6.0",
         "symfony/http-foundation": "^4.4|^5.3|^6.0",
         "symfony/http-kernel": "^4.4|^5.3|^6.0",


### PR DESCRIPTION
Just to fix composer update issues, where composer prefers not to updated lexik bundle because it required deprecation-contracts v.2 and all other packages v3
![image](https://user-images.githubusercontent.com/1075618/144193901-15e525b0-bdcc-4ffa-a736-47fd5e1bb4d3.png)

```shell
dev@05584e3c9f0b:/app$ composer why-not lexik/jwt-authentication-bundle 2.14.1
lexik/jwt-authentication-bundle  v2.14.1     requires          symfony/deprecation-contracts (^2.4)
macroative/api                   dev-master  does not require  symfony/deprecation-contracts (but v3.0.0 is installed)
```