### PR TITLE
[CI] Update tested versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,30 +18,26 @@ jobs:
                       composer-flags: '--prefer-stable --prefer-lowest'
                       can-fail: false
                     # LTS with latest stable PHP
-                    - php: 8.0
-                      symfony: 4.4.*
+                    - php: 8.1
+                      symfony: 5.4.*
                       composer-flags: '--prefer-stable'
                       can-fail: false
                     # Stable Symfony branches
-                    - php: 7.2
+                    - php: 7.4
                       symfony: 4.4.*
                       composer-flags: '--prefer-stable'
                       can-fail: false
-                    - php: 7.3
+                    - php: 8.0
                       symfony: 5.3.*
-                      composer-flags: '--prefer-stable' # Needed to force `lcobucci/jwt` to install a usable version
+                      composer-flags: '--prefer-stable'
+                      can-fail: false
+                    - php: 8.0
+                      symfony: 6.0.*
+                      composer-flags: '--prefer-stable'
                       can-fail: false
                     # Development Symfony branches
-                    - php: 7.4
-                      symfony: 5.4.*@dev
-                      composer-flags: ''
-                      can-fail: false
-                    - php: 8.0
-                      symfony: 5.4.*@dev
-                      composer-flags: ''
-                      can-fail: false
-                    - php: 8.0
-                      symfony: 6.0.*@dev
+                    - php: 8.1
+                      symfony: 6.1.*@dev
                       composer-flags: ''
                       can-fail: false
 
@@ -67,11 +63,11 @@ jobs:
                   tools: "composer:v2,flex"
 
             - name: "Set Composer stability"
-              if: "matrix.symfony == '5.4.*@dev' || matrix.symfony == '6.0.*@dev'"
+              if: "matrix.symfony == '6.1.*@dev'"
               run: "composer config minimum-stability dev"
 
             - name: "Remove symfony/security-guard"
-              if: "matrix.symfony == '6.0.*@dev'"
+              if: "matrix.symfony == '6.0.*' || matrix.symfony == '6.1.*@dev'"
               run: "composer remove --dev --no-update symfony/security-guard"
 
             - name: "Install dependencies"


### PR DESCRIPTION
Symfony 5.4 & 6.0 are now stable, and PHP 7.4 is EOM (security fixes only).