### PR TITLE
Typo-Fix in the ChainUserProvider

### DIFF
--- a/Security/Authenticator/JWTAuthenticator.php
+++ b/Security/Authenticator/JWTAuthenticator.php
@@ -207,9 +207,9 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
                 try {
                     if ($provider instanceof PayloadAwareUserProviderInterface) {
                         if (method_exists(PayloadAwareUserProviderInterface::class, 'loadUserByIdentifierAndPayload')) {
-                            return $this->userProvider->loadUserByIdentifierAndPayload($identity, $payload);
+                            return $provider->loadUserByIdentifierAndPayload($identity, $payload);
                         } else {
-                            return $this->userProvider->loadUserByUsernameAndPayload($identity, $payload);
+                            return $provider->loadUserByUsernameAndPayload($identity, $payload);
                         }
                     }
 


### PR DESCRIPTION
Hi,

found this bug as I wanted to integrate the JWTAuthenticator in a ChainAuthenticator. It fixes the issue #971.