### PR TITLE
Translate message errors

### DIFF
--- a/Resources/config/guard_authenticator.xml
+++ b/Resources/config/guard_authenticator.xml
@@ -14,6 +14,7 @@
             <argument type="service">
                 <service class="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage" />
             </argument>
+            <argument type="service" id="translator" on-invalid="null" />
         </service>
     </services>
 </container>

--- a/Resources/config/response_interceptor.xml
+++ b/Resources/config/response_interceptor.xml
@@ -17,6 +17,7 @@
         <service id="lexik_jwt_authentication.handler.authentication_failure" class="Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationFailureHandler">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="translator" on-invalid="null" />
         </service>
         <service id="Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationFailureHandler" alias="lexik_jwt_authentication.handler.authentication_failure" />
     </services>

--- a/Resources/config/token_authenticator.xml
+++ b/Resources/config/token_authenticator.xml
@@ -10,6 +10,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="lexik_jwt_authentication.extractor.chain_extractor"/>
             <argument /> <!-- User Provider -->
+            <argument type="service" id="translator" on-invalid="null" />
         </service>
 
     </services>

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * AuthenticationFailureHandler.
@@ -23,9 +24,15 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
      */
     protected $dispatcher;
 
-    public function __construct(EventDispatcherInterface $dispatcher)
+    /**
+     * @var TranslatorInterface|null
+     */
+    private $translator;
+
+    public function __construct(EventDispatcherInterface $dispatcher, TranslatorInterface $translator = null)
     {
         $this->dispatcher = $dispatcher;
+        $this->translator = $translator;
     }
 
     /**
@@ -35,6 +42,9 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
     {
         $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());
         $statusCode = self::mapExceptionCodeToStatusCode($exception->getCode());
+        if ($this->translator) {
+            $errorMessage = $this->translator->trans($exception->getMessageKey(), $exception->getMessageData(), 'security');
+        }
 
         $event = new AuthenticationFailureEvent(
             $exception,

--- a/Tests/Security/Authenticator/JWTAuthenticatorTest.php
+++ b/Tests/Security/Authenticator/JWTAuthenticatorTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\FormLoginAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /** @requires PHP >= 7.2 */
 class JWTAuthenticatorTest extends TestCase
@@ -186,6 +187,33 @@ class JWTAuthenticatorTest extends TestCase
         $this->assertSame($expectedResponse->getMessage(), $response->getMessage());
     }
 
+    public function testOnAuthenticationFailureWithInvalidTokenTranslatedMessage() {
+        $authException = new InvalidTokenException();
+        $expectedResponse = new JWTAuthenticationFailureResponse('translated message');
+
+        $dispatcher = $this->getEventDispatcherMock();
+        $this->expectEvent(Events::JWT_INVALID, new JWTInvalidEvent($authException, $expectedResponse), $dispatcher);
+
+        $translator = $this->getTranslatorMock();
+        $translator->expects($this->once())
+            ->method('trans')
+            ->with('Invalid JWT Token', [])
+            ->willReturn('translated message');
+
+        $authenticator = new JWTAuthenticator(
+            $this->getJWTManagerMock(),
+            $dispatcher,
+            $this->getTokenExtractorMock(),
+            $this->getUserProviderMock(),
+            $translator
+        );
+
+        $response = $authenticator->onAuthenticationFailure($this->getRequestMock(), $authException);
+
+        $this->assertEquals($expectedResponse, $response);
+        $this->assertSame('translated message', $response->getMessage());
+    }
+
     public function testStart()
     {
         $authException = new MissingTokenException('JWT Token not found');
@@ -293,6 +321,13 @@ class JWTAuthenticatorTest extends TestCase
     private function getUserProviderMock()
     {
         return $this->getMockBuilder(DummyUserProvider::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    private function getTranslatorMock()
+    {
+        return $this->getMockBuilder(TranslatorInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "symfony/property-access": "^4.4|^5.3|^6.0",
         "symfony/security-bundle": "^4.4|^5.3|^6.0",
         "symfony/security-core": "^4.4|^5.3|^6.0",
-        "symfony/security-http": "^4.4|^5.3|^6.0"
+        "symfony/security-http": "^4.4|^5.3|^6.0",
+        "symfony/translation-contracts": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "symfony/browser-kit": "^4.4|^5.3|^6.0",


### PR DESCRIPTION
Hi @chalasr,

The exception messages are not translated even if the locale was set.
I largely ~copied~ inspired my code from this PR: symfony/symfony#38037 to translate the message.

Let me know if any changes need to be done.