### PR TITLE
Fix authentication with integer as useridentifier

### DIFF
--- a/Security/Authenticator/JWTAuthenticator.php
+++ b/Security/Authenticator/JWTAuthenticator.php
@@ -115,7 +115,7 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
         }
 
         $passport = new SelfValidatingPassport(
-            new UserBadge($payload[$idClaim],
+            new UserBadge((string)$payload[$idClaim],
             function ($userIdentifier) use($payload) {
                 return $this->loadUser($payload, $userIdentifier);
             })

--- a/Tests/Security/Authenticator/JWTAuthenticatorTest.php
+++ b/Tests/Security/Authenticator/JWTAuthenticatorTest.php
@@ -69,6 +69,35 @@ class JWTAuthenticatorTest extends TestCase
         $this->assertSame($userStub, ($authenticator->authenticate($this->getRequestMock()))->getUser());
     }
 
+    public function testAuthenticateWithIntegerIdentifier() {
+        $userIdClaim = 'sub';
+        $payload = [$userIdClaim => 1];
+        $rawToken = 'token';
+        $userRoles = ['ROLE_USER'];
+
+        $userStub = new AdvancedUserStub(1, 'password', 'user@gmail.com', $userRoles);
+
+        $jwtManager = $this->getJWTManagerMock(null, $userIdClaim);
+        $jwtManager
+            ->method('parse')
+            ->willReturn(['sub' => 1]);
+
+        $userProvider = $this->getUserProviderMock();
+        $userProvider
+            ->method('loadUserByIdentifierAndPayload')
+            ->with($payload['sub'], $payload)
+            ->willReturn($userStub);
+
+        $authenticator = new JWTAuthenticator(
+            $jwtManager,
+            $this->getEventDispatcherMock(),
+            $this->getTokenExtractorMock($rawToken),
+            $userProvider
+        );
+
+        $this->assertSame($userStub, ($authenticator->authenticate($this->getRequestMock()))->getUser());
+    }
+
     public function testAuthenticateWithExpiredTokenThrowsException() {
         $jwtManager = $this->getJWTManagerMock();
         $jwtManager->method('parse')


### PR DESCRIPTION
Fix authentication with integer as useridentifier caused argument type error with UserBadge (Maybe only with Symfony >= 6.0)