### PR TITLE
Fix a type related depreciation with php 8.1

### DIFF
--- a/TokenExtractor/AuthorizationHeaderTokenExtractor.php
+++ b/TokenExtractor/AuthorizationHeaderTokenExtractor.php
@@ -46,7 +46,7 @@ class AuthorizationHeaderTokenExtractor implements TokenExtractorInterface
             return $authorizationHeader;
         }
 
-        $headerParts = explode(' ', $authorizationHeader);
+        $headerParts = explode(' ', (string) $authorizationHeader);
 
         if (!(2 === count($headerParts) && 0 === strcasecmp($headerParts[0], $this->prefix))) {
             return false;


### PR DESCRIPTION
With php 8.1 passing null as a second parameter to the explode function is deprecated. 
See https://www.php.net/manual/en/migration81.deprecated.php
`$request->headers->get($this->name);` can return null so i suggest a simple cast to fix this deprecation.

