### PR TITLE
Add Request object into AuthenticationFailureEvent

### DIFF
--- a/Event/AuthenticationFailureEvent.php
+++ b/Event/AuthenticationFailureEvent.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -24,10 +25,16 @@ class AuthenticationFailureEvent extends Event
      */
     protected $response;
 
-    public function __construct(AuthenticationException $exception, Response $response)
+    /**
+     * @var Request|null
+     */
+    private $request;
+
+    public function __construct(AuthenticationException $exception, Response $response, ?Request $request = null)
     {
         $this->exception = $exception;
         $this->response = $response;
+        $this->request = $request;
     }
 
     /**
@@ -46,8 +53,16 @@ class AuthenticationFailureEvent extends Event
         return $this->response;
     }
 
-    public function setResponse(Response $response)
+    public function setResponse(Response $response): void
     {
         $this->response = $response;
+    }
+
+    public function getRequest(): ?Request {
+        return $this->request;
+    }
+
+    public function setRequest(Request $request) {
+        $this->request = $request;
     }
 }

--- a/Event/JWTNotFoundEvent.php
+++ b/Event/JWTNotFoundEvent.php
@@ -2,7 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Event;
 
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\{Response, Request};
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
@@ -13,9 +13,10 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  */
 class JWTNotFoundEvent extends AuthenticationFailureEvent implements JWTFailureEventInterface
 {
-    public function __construct(AuthenticationException $exception = null, Response $response = null)
+    public function __construct(AuthenticationException $exception = null, Response $response = null, Request $request = null)
     {
         $this->exception = $exception;
         $this->response = $response;
+        $this->request = $request;
     }
 }

--- a/Security/Authenticator/JWTAuthenticator.php
+++ b/Security/Authenticator/JWTAuthenticator.php
@@ -86,7 +86,7 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
     public function start(Request $request, AuthenticationException $authException = null): Response
     {
         $exception = new MissingTokenException('JWT Token not found', 0, $authException);
-        $event = new JWTNotFoundEvent($exception, new JWTAuthenticationFailureResponse($exception->getMessageKey()));
+        $event = new JWTNotFoundEvent($exception, new JWTAuthenticationFailureResponse($exception->getMessageKey()), $request);
 
         $this->eventDispatcher->dispatch($event, Events::JWT_NOT_FOUND);
 
@@ -149,10 +149,10 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
         $response = new JWTAuthenticationFailureResponse($errorMessage);
 
         if ($exception instanceof ExpiredTokenException) {
-            $event = new JWTExpiredEvent($exception, $response);
+            $event = new JWTExpiredEvent($exception, $response, $request);
             $eventName = Events::JWT_EXPIRED;
         } else {
-            $event = new JWTInvalidEvent($exception, $response);
+            $event = new JWTInvalidEvent($exception, $response, $request);
             $eventName = Events::JWT_INVALID;
         }
 

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -95,7 +95,7 @@ class JWTListener
 
             $response = new JWTAuthenticationFailureResponse($failed->getMessage());
 
-            $jwtInvalidEvent = new JWTInvalidEvent($failed, $response);
+            $jwtInvalidEvent = new JWTInvalidEvent($failed, $response, $event->getRequest());
             $this->dispatcher->dispatch($jwtInvalidEvent, Events::JWT_INVALID);
 
             $event->setResponse($jwtInvalidEvent->getResponse());

--- a/Security/Guard/JWTTokenAuthenticator.php
+++ b/Security/Guard/JWTTokenAuthenticator.php
@@ -173,10 +173,10 @@ class JWTTokenAuthenticator implements AuthenticatorInterface
         $response = new JWTAuthenticationFailureResponse($errorMessage);
 
         if ($authException instanceof ExpiredTokenException) {
-            $event = new JWTExpiredEvent($authException, $response);
+            $event = new JWTExpiredEvent($authException, $response, $request);
             $eventName = Events::JWT_EXPIRED;
         } else {
-            $event = new JWTInvalidEvent($authException, $response);
+            $event = new JWTInvalidEvent($authException, $response, $request);
             $eventName = Events::JWT_INVALID;
         }
 
@@ -201,7 +201,7 @@ class JWTTokenAuthenticator implements AuthenticatorInterface
     public function start(Request $request, AuthenticationException $authException = null)
     {
         $exception = new MissingTokenException('JWT Token not found', 0, $authException);
-        $event = new JWTNotFoundEvent($exception, new JWTAuthenticationFailureResponse($exception->getMessageKey()));
+        $event = new JWTNotFoundEvent($exception, new JWTAuthenticationFailureResponse($exception->getMessageKey()), $request);
 
         $this->dispatcher->dispatch($event, Events::JWT_NOT_FOUND);
 

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -48,7 +48,8 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
 
         $event = new AuthenticationFailureEvent(
             $exception,
-            new JWTAuthenticationFailureResponse($errorMessage, $statusCode)
+            new JWTAuthenticationFailureResponse($errorMessage, $statusCode),
+            $request
         );
 
         $this->dispatcher->dispatch($event, Events::AUTHENTICATION_FAILURE);

--- a/Tests/Security/Authenticator/JWTAuthenticatorTest.php
+++ b/Tests/Security/Authenticator/JWTAuthenticatorTest.php
@@ -199,9 +199,9 @@ class JWTAuthenticatorTest extends TestCase
     public function testOnAuthenticationFailureWithInvalidToken() {
         $authException = new InvalidTokenException();
         $expectedResponse = new JWTAuthenticationFailureResponse('Invalid JWT Token');
-
+        $request = $this->getRequestMock();
         $dispatcher = $this->getEventDispatcherMock();
-        $this->expectEvent(Events::JWT_INVALID, new JWTInvalidEvent($authException, $expectedResponse), $dispatcher);
+        $this->expectEvent(Events::JWT_INVALID, new JWTInvalidEvent($authException, $expectedResponse, $request), $dispatcher);
 
         $authenticator = new JWTAuthenticator(
             $this->getJWTManagerMock(),
@@ -210,7 +210,7 @@ class JWTAuthenticatorTest extends TestCase
             $this->getUserProviderMock()
         );
 
-        $response = $authenticator->onAuthenticationFailure($this->getRequestMock(), $authException);
+        $response = $authenticator->onAuthenticationFailure($request, $authException);
 
         $this->assertEquals($expectedResponse, $response);
         $this->assertSame($expectedResponse->getMessage(), $response->getMessage());
@@ -219,9 +219,9 @@ class JWTAuthenticatorTest extends TestCase
     public function testOnAuthenticationFailureWithInvalidTokenTranslatedMessage() {
         $authException = new InvalidTokenException();
         $expectedResponse = new JWTAuthenticationFailureResponse('translated message');
-
+        $request = $this->getRequestMock();
         $dispatcher = $this->getEventDispatcherMock();
-        $this->expectEvent(Events::JWT_INVALID, new JWTInvalidEvent($authException, $expectedResponse), $dispatcher);
+        $this->expectEvent(Events::JWT_INVALID, new JWTInvalidEvent($authException, $expectedResponse, $request), $dispatcher);
 
         $translator = $this->getTranslatorMock();
         $translator->expects($this->once())
@@ -237,7 +237,7 @@ class JWTAuthenticatorTest extends TestCase
             $translator
         );
 
-        $response = $authenticator->onAuthenticationFailure($this->getRequestMock(), $authException);
+        $response = $authenticator->onAuthenticationFailure($request, $authException);
 
         $this->assertEquals($expectedResponse, $response);
         $this->assertSame('translated message', $response->getMessage());
@@ -247,9 +247,9 @@ class JWTAuthenticatorTest extends TestCase
     {
         $authException = new MissingTokenException('JWT Token not found');
         $failureResponse = new JWTAuthenticationFailureResponse($authException->getMessageKey());
-
+        $request = $this->getRequestMock();
         $dispatcher = $this->getEventDispatcherMock();
-        $this->expectEvent(Events::JWT_NOT_FOUND, new JWTNotFoundEvent($authException, $failureResponse), $dispatcher);
+        $this->expectEvent(Events::JWT_NOT_FOUND, new JWTNotFoundEvent($authException, $failureResponse, $request), $dispatcher);
 
         $authenticator = new JWTAuthenticator(
             $this->getJWTManagerMock(),
@@ -258,7 +258,7 @@ class JWTAuthenticatorTest extends TestCase
             $this->getUserProviderMock()
         );
 
-        $response = $authenticator->start($this->getRequestMock());
+        $response = $authenticator->start($request);
 
         $this->assertEquals($failureResponse, $response);
         $this->assertSame($failureResponse->getMessage(), $response->getMessage());

--- a/Tests/Security/Guard/JWTTokenAuthenticatorTest.php
+++ b/Tests/Security/Guard/JWTTokenAuthenticatorTest.php
@@ -277,9 +277,9 @@ class JWTTokenAuthenticatorTest extends TestCase
     {
         $authException = new InvalidTokenException();
         $expectedResponse = new JWTAuthenticationFailureResponse('Invalid JWT Token');
-
+        $request = $this->getRequestMock();
         $dispatcher = $this->getEventDispatcherMock();
-        $this->expectEvent(Events::JWT_INVALID, new JWTInvalidEvent($authException, $expectedResponse), $dispatcher);
+        $this->expectEvent(Events::JWT_INVALID, new JWTInvalidEvent($authException, $expectedResponse, $request), $dispatcher);
 
         $authenticator = new JWTTokenAuthenticator(
             $this->getJWTManagerMock(),
@@ -288,7 +288,7 @@ class JWTTokenAuthenticatorTest extends TestCase
             $this->getTokenStorageMock()
         );
 
-        $response = $authenticator->onAuthenticationFailure($this->getRequestMock(), $authException);
+        $response = $authenticator->onAuthenticationFailure($request, $authException);
 
         $this->assertEquals($expectedResponse, $response);
         $this->assertSame($expectedResponse->getMessage(), $response->getMessage());
@@ -298,9 +298,9 @@ class JWTTokenAuthenticatorTest extends TestCase
     {
         $authException = new InvalidTokenException();
         $expectedResponse = new JWTAuthenticationFailureResponse('translated message');
-
+        $request = $this->getRequestMock();
         $dispatcher = $this->getEventDispatcherMock();
-        $this->expectEvent(Events::JWT_INVALID, new JWTInvalidEvent($authException, $expectedResponse), $dispatcher);
+        $this->expectEvent(Events::JWT_INVALID, new JWTInvalidEvent($authException, $expectedResponse, $request), $dispatcher);
 
         $translator = $this->getTranslatorMock();
         $translator->expects($this->once())->method('trans')->with('Invalid JWT Token', [])->willReturn('translated message');
@@ -313,7 +313,7 @@ class JWTTokenAuthenticatorTest extends TestCase
             $translator
         );
 
-        $response = $authenticator->onAuthenticationFailure($this->getRequestMock(), $authException);
+        $response = $authenticator->onAuthenticationFailure($request, $authException);
 
         $this->assertEquals($expectedResponse, $response);
         $this->assertSame($expectedResponse->getMessage(), $response->getMessage());
@@ -323,9 +323,9 @@ class JWTTokenAuthenticatorTest extends TestCase
     {
         $authException = new MissingTokenException('JWT Token not found');
         $failureResponse = new JWTAuthenticationFailureResponse($authException->getMessageKey());
-
+        $request = $this->getRequestMock();
         $dispatcher = $this->getEventDispatcherMock();
-        $this->expectEvent(Events::JWT_NOT_FOUND, new JWTNotFoundEvent($authException, $failureResponse), $dispatcher);
+        $this->expectEvent(Events::JWT_NOT_FOUND, new JWTNotFoundEvent($authException, $failureResponse, $request), $dispatcher);
 
         $authenticator = new JWTTokenAuthenticator(
             $this->getJWTManagerMock(),
@@ -334,7 +334,7 @@ class JWTTokenAuthenticatorTest extends TestCase
             $this->getTokenStorageMock()
         );
 
-        $response = $authenticator->start($this->getRequestMock());
+        $response = $authenticator->start($request);
 
         $this->assertEquals($failureResponse, $response);
         $this->assertSame($failureResponse->getMessage(), $response->getMessage());


### PR DESCRIPTION
Hey, @chalasr. Thanks for ur bundle. 
Want to get the Request object in a subscriber for AuthenticationFailureEvents for passing some data regarding the occurred exception to e.g. `symfony:terminate` event subscriber . 

Regards.