### PR TITLE
Allow for creation of tokens without exp

### DIFF
--- a/Services/JWSProvider/LcobucciJWSProvider.php
+++ b/Services/JWSProvider/LcobucciJWSProvider.php
@@ -109,7 +109,9 @@ class LcobucciJWSProvider implements JWSProviderInterface
             $exp = $payload['exp'] ?? $now + $this->ttl;
             unset($payload['exp']);
 
-            $jws->expiresAt($exp instanceof \DateTimeImmutable ? $exp : ($this->useDateObjects ? new \DateTimeImmutable("@$exp") : $exp));
+            if($exp) {
+                $jws->expiresAt($exp instanceof \DateTimeImmutable ? $exp : ($this->useDateObjects ? new \DateTimeImmutable("@$exp") : $exp));
+            }
         }
 
         if (isset($payload['sub'])) {


### PR DESCRIPTION
Allow exp=0 to be set in the payload during creation, which will create a token without an EXP. Related to #676 and #889.