### PR TITLE
Allow additional public keys to be set by value, as well as by path

### DIFF
--- a/Resources/doc/1-configuration-reference.md
+++ b/Resources/doc/1-configuration-reference.md
@@ -16,10 +16,11 @@ lexik_jwt_authentication:
     public_key: '%kernel.project_dir%/config/jwt/public.pem'  # path to the public key OR raw public key, required for verifying tokens
     pass_phrase: 'yourpassphrase' # required for creating tokens
     # Additional public keys are used to verify signature of incoming tokens, if the key provided in "public_key" configuration node doesn't verify the token
+    # Can be paths to public key files OR raw public keys
     additional_public_keys:
         - '%kernel.project_dir%/config/jwt/public1.pem'
         - '%kernel.project_dir%/config/jwt/public2.pem'
-        - '%kernel.project_dir%/config/jwt/public3.pem'
+        - '%env(PUBLIC3_KEY_TEXT)%'
 ```
 
 #### Using HMAC

--- a/Services/KeyLoader/AbstractKeyLoader.php
+++ b/Services/KeyLoader/AbstractKeyLoader.php
@@ -48,7 +48,7 @@ abstract class AbstractKeyLoader implements KeyLoaderInterface
 
         foreach ($this->additionalPublicKeys as $key) {
             if (!$key) {
-                throw new \RuntimeException(sprintf('Additional public key is not set correctly. Check the "lexik_jwt_authentication.additional_public_keys" configuration key', $key));
+                continue;
             }
             if (is_file($key) && !is_readable($key)) {
                 throw new \RuntimeException(sprintf('Additional public key "%s" is not readable. Did you correctly set the "lexik_jwt_authentication.additional_public_keys" configuration key?', $key));

--- a/Services/KeyLoader/AbstractKeyLoader.php
+++ b/Services/KeyLoader/AbstractKeyLoader.php
@@ -47,8 +47,11 @@ abstract class AbstractKeyLoader implements KeyLoaderInterface
         $contents = [];
 
         foreach ($this->additionalPublicKeys as $key) {
-            if (!$key && (!is_file($key) || !is_readable($key))) {
-                throw new \RuntimeException(sprintf('Additional public key "%s" does not exist or is not readable. Did you correctly set the "lexik_jwt_authentication.additional_public_keys" configuration key?', $key));
+            if (!$key) {
+                throw new \RuntimeException(sprintf('Additional public key is not set correctly. Check the "lexik_jwt_authentication.additional_public_keys" configuration key', $key));
+            }
+            if (is_file($key) && !is_readable($key)) {
+                throw new \RuntimeException(sprintf('Additional public key "%s" is not readable. Did you correctly set the "lexik_jwt_authentication.additional_public_keys" configuration key?', $key));
             }
 
             $contents[] = is_file($key) ? file_get_contents($key) : $key;

--- a/Services/KeyLoader/AbstractKeyLoader.php
+++ b/Services/KeyLoader/AbstractKeyLoader.php
@@ -47,7 +47,7 @@ abstract class AbstractKeyLoader implements KeyLoaderInterface
         $contents = [];
 
         foreach ($this->additionalPublicKeys as $key) {
-            if (!$key || !is_file($key) || !is_readable($key)) {
+            if (!$key && (!is_file($key) || !is_readable($key))) {
                 throw new \RuntimeException(sprintf('Additional public key "%s" does not exist or is not readable. Did you correctly set the "lexik_jwt_authentication.additional_public_keys" configuration key?', $key));
             }
 

--- a/Tests/Services/KeyLoader/AbstractTestKeyLoader.php
+++ b/Tests/Services/KeyLoader/AbstractTestKeyLoader.php
@@ -46,6 +46,40 @@ abstract class AbstractTestKeyLoader extends TestCase
         $loader->getAdditionalPublicKeys();
     }
 
+    public function testLoadingAdditionalPublicKeysAsStrings()
+    {
+        $additionalPublicKeys = ['myKeyText1', 'myKeyText2'];
+
+        $className = $this->getClassName();
+        /** @var AbstractKeyLoader $loader */
+        $loader = new $className('private.pem', 'public.pem', 'foobar', $additionalPublicKeys);
+
+        $this->assertSame($additionalPublicKeys, $loader->getAdditionalPublicKeys());
+    }
+
+    public function testLoadingAdditionalPublicKeysFromFiles()
+    {
+        file_put_contents('additional-public-1.pem', 'myKeyTextFromFile1');
+        file_put_contents('additional-public-2.pem', 'myKeyTextFromFile2');
+
+        $className = $this->getClassName();
+        /** @var AbstractKeyLoader $loader */
+        $loader = new $className('private.pem', 'public.pem', 'foobar', ['additional-public-1.pem', 'additional-public-2.pem']);
+
+        $this->assertSame(['myKeyTextFromFile1', 'myKeyTextFromFile2'], $loader->getAdditionalPublicKeys());
+    }
+
+    public function testLoadingAdditionalPublicKeysFromFilesAndAsStrings()
+    {
+        file_put_contents('additional-public-1.pem', 'myKeyTextFromFile1');
+
+        $className = $this->getClassName();
+        /** @var AbstractKeyLoader $loader */
+        $loader = new $className('private.pem', 'public.pem', 'foobar', ['additional-public-1.pem', 'myKeyText2']);
+
+        $this->assertSame(['myKeyTextFromFile1', 'myKeyText2'], $loader->getAdditionalPublicKeys());
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -61,15 +95,11 @@ abstract class AbstractTestKeyLoader extends TestCase
      */
     protected function removeKeysIfExist()
     {
-        $privateKey = 'private.pem';
-        $publicKey = 'public.pem';
-
-        if (file_exists($publicKey)) {
-            unlink($publicKey);
-        }
-
-        if (file_exists($privateKey)) {
-            unlink($privateKey);
+        $keys = ['private.pem', 'public.pem', 'additional-public-1.pem', 'additional-public-2.pem'];
+        foreach ($keys as $key) {
+            if (file_exists($key)) {
+                unlink($key);
+            }
         }
     }
 

--- a/Tests/Services/KeyLoader/AbstractTestKeyLoader.php
+++ b/Tests/Services/KeyLoader/AbstractTestKeyLoader.php
@@ -35,15 +35,12 @@ abstract class AbstractTestKeyLoader extends TestCase
         $this->keyLoader->loadKey('wrongType');
     }
 
-    public function testLoadingNullAdditionalPublicKey()
+    public function testFalsyAdditionalPublicKeysSkipped()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Additional public key is not set correctly. Check the "lexik_jwt_authentication.additional_public_keys" configuration key');
-
         $className = $this->getClassName();
         /** @var AbstractKeyLoader $loader */
-        $loader = new $className('private.pem', 'public.pem', 'foobar', [null]);
-        $loader->getAdditionalPublicKeys();
+        $loader = new $className('private.pem', 'public.pem', 'foobar', [null, false, '']);
+        $this->assertSame([], $loader->getAdditionalPublicKeys());
     }
 
     public function testLoadingAdditionalPublicKeysAsStrings()

--- a/Tests/Services/KeyLoader/AbstractTestKeyLoader.php
+++ b/Tests/Services/KeyLoader/AbstractTestKeyLoader.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Services\KeyLoader;
 
+use Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\AbstractKeyLoader;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\KeyLoaderInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Tests\ForwardCompatTestCaseTrait;
 use PHPUnit\Framework\TestCase;
@@ -34,6 +35,17 @@ abstract class AbstractTestKeyLoader extends TestCase
         $this->keyLoader->loadKey('wrongType');
     }
 
+    public function testLoadingNullAdditionalPublicKey()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Additional public key is not set correctly. Check the "lexik_jwt_authentication.additional_public_keys" configuration key');
+
+        $className = $this->getClassName();
+        /** @var AbstractKeyLoader $loader */
+        $loader = new $className('private.pem', 'public.pem', 'foobar', [null]);
+        $loader->getAdditionalPublicKeys();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -60,4 +72,6 @@ abstract class AbstractTestKeyLoader extends TestCase
             unlink($privateKey);
         }
     }
+
+    abstract protected function getClassName(): string;
 }

--- a/Tests/Services/KeyLoader/OpenSSLKeyLoaderTest.php
+++ b/Tests/Services/KeyLoader/OpenSSLKeyLoaderTest.php
@@ -42,4 +42,9 @@ class OpenSSLKeyLoaderTest extends AbstractTestKeyLoader
 
         $this->keyLoader->loadKey('private');
     }
+
+    protected function getClassName(): string
+    {
+        return OpenSSLKeyLoader::class;
+    }
 }

--- a/Tests/Services/KeyLoader/RawKeyLoaderTest.php
+++ b/Tests/Services/KeyLoader/RawKeyLoaderTest.php
@@ -27,4 +27,9 @@ class RawKeyLoaderTest extends AbstractTestKeyLoader
     {
         $this->assertSame('private.pem', $this->keyLoader->loadKey('private'));
     }
+
+    protected function getClassName(): string
+    {
+        return RawKeyLoader::class;
+    }
 }


### PR DESCRIPTION
https://github.com/lexik/LexikJWTAuthenticationBundle/pull/928 added an excellent feature, allowing additional public keys to be specified.

However, unlike the main public key, this can only be specified as a file path, rather than being passed directly as a string. The ability to pass keys as strings is useful when setting keys via environment variables, so I want to be able to configure the additional public keys as either file paths or as raw strings.