### PR TITLE
[Docs] Tweaks and improvements

### DIFF
--- a/Resources/doc/1-configuration-reference.rst
+++ b/Resources/doc/1-configuration-reference.rst
@@ -8,88 +8,88 @@ Minimal configuration
 ~~~~~~~~~~~~~~~~~~~~~
 
 Using RSA/ECDSA
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
-   # config/packages/lexik_jwt_authentication.yaml
-   #...
-   lexik_jwt_authentication:
-       secret_key: '%kernel.project_dir%/config/jwt/private.pem' # path to the secret key OR raw secret key, required for creating tokens
-       public_key: '%kernel.project_dir%/config/jwt/public.pem'  # path to the public key OR raw public key, required for verifying tokens
-       pass_phrase: 'yourpassphrase' # required for creating tokens
-       # Additional public keys are used to verify signature of incoming tokens, if the key provided in "public_key" configuration node doesn't verify the token
-       additional_public_keys:
-           - '%kernel.project_dir%/config/jwt/public1.pem'
-           - '%kernel.project_dir%/config/jwt/public2.pem'
-           - '%kernel.project_dir%/config/jwt/public3.pem'
+    # config/packages/lexik_jwt_authentication.yaml
+    #...
+    lexik_jwt_authentication:
+        secret_key: '%kernel.project_dir%/config/jwt/private.pem' # path to the secret key OR raw secret key, required for creating tokens
+        public_key: '%kernel.project_dir%/config/jwt/public.pem'  # path to the public key OR raw public key, required for verifying tokens
+        pass_phrase: 'yourpassphrase' # required for creating tokens
+        # Additional public keys are used to verify signature of incoming tokens, if the key provided in "public_key" configuration node doesn't verify the token
+        additional_public_keys:
+            - '%kernel.project_dir%/config/jwt/public1.pem'
+            - '%kernel.project_dir%/config/jwt/public2.pem'
+            - '%kernel.project_dir%/config/jwt/public3.pem'
 
 Using HMAC
-^^^^^^^^^^
+~~~~~~~~~~
 
 .. code-block:: yaml
 
-   #  config/packages/lexik_jwt_authentication.yaml
-   #...
-   lexik_jwt_authentication:
-       secret_key: yoursecret
+    # config/packages/lexik_jwt_authentication.yaml
+    #...
+    lexik_jwt_authentication:
+        secret_key: yoursecret
 
 Full default configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
-   # config/packages/lexik_jwt_authentication.yaml
-   # ...
-   lexik_jwt_authentication:
-       secret_key: ~
-       public_key: ~
-       pass_phrase: ~
-       token_ttl: 3600 # token TTL in seconds, defaults to 1 hour
-       user_identity_field: username  # key under which the user identity will be stored in the token payload
-       clock_skew: 0
+    # config/packages/lexik_jwt_authentication.yaml
+    # ...
+    lexik_jwt_authentication:
+        secret_key: ~
+        public_key: ~
+        pass_phrase: ~
+        token_ttl: 3600 # token TTL in seconds, defaults to 1 hour
+        user_identity_field: username # key under which the user identity will be stored in the token payload
+        clock_skew: 0
 
-       # token encoding/decoding settings
-       encoder:
-           # token encoder/decoder service - default implementation based on the lcobucci/jwt library
-           service:            lexik_jwt_authentication.encoder.lcobucci
+        # token encoding/decoding settings
+        encoder:
+            # token encoder/decoder service - default implementation based on the lcobucci/jwt library
+            service:            lexik_jwt_authentication.encoder.lcobucci
 
-           # encryption algorithm used by the encoder service
-           signature_algorithm: RS256
+            # encryption algorithm used by the encoder service
+            signature_algorithm: RS256
 
-       # token extraction settings
-       token_extractors:
-           # look for a token as Authorization Header
-           authorization_header:
-               enabled: true
-               prefix:  Bearer
-               name:    Authorization
+        # token extraction settings
+        token_extractors:
+            # look for a token as Authorization Header
+            authorization_header:
+                enabled: true
+                prefix:  Bearer
+                name:    Authorization
 
-           # check token in a cookie
-           cookie:
-               enabled: false
-               name:    BEARER
-               
-           # check token in query string parameter
-           query_parameter:
-               enabled: false
-               name:    bearer
-           
-           # check token in a cookie
-           split_cookie:
-               enabled: false
-               cookies:
-                   - jwt_hp
-                   - jwt_s
-                   
-       # remove the token from the response body when using cookies
-       remove_token_from_body_when_cookies_used: true
+            # check token in a cookie
+            cookie:
+                enabled: false
+                name:    BEARER
+
+            # check token in query string parameter
+            query_parameter:
+                enabled: false
+                name:    bearer
+
+            # check token in a cookie
+            split_cookie:
+                enabled: false
+                cookies:
+                    - jwt_hp
+                    - jwt_s
+
+        # remove the token from the response body when using cookies
+        remove_token_from_body_when_cookies_used: true
 
 Encoder configuration
-^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~
 
 service
-'''''''
+.......
 
 Defaults to ``lexik_jwt_authentication.encoder.lcobucci`` which is based
 on the `Lcobucci/JWT <https://github.com/lcobucci/jwt>`__ library.
@@ -101,11 +101,11 @@ which is based on the great
 `web-token/jwt-framework <https://github.com/web-token/jwt-framework>`__
 library.
 
-To create your own encoder service, see the `JWT encoder service
-customization chapter <5-encoder-service>`__.
+To create your own encoder service, see the
+:doc:`JWT encoder service customization chapter </5-encoder-service>`.
 
 signature_algorithm
-'''''''''''''''''''
+...................
 
 One of the algorithms supported by the default encoder for the
 configured `crypto engine <#crypto_engine>`__.
@@ -115,72 +115,72 @@ configured `crypto engine <#crypto_engine>`__.
 -  ES256, ES384, ES512 (ECDSA)
 
 Automatically generating cookies
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You are now able to automatically generate secure and httpOnly cookies
 when the cookie token extractor is enabled
 `#753 <https://github.com/lexik/LexikJWTAuthenticationBundle/pull/753>`__.
 
-::
+.. code-block:: yaml
 
-   token_extractors: 
-       cookie: 
-           enabled: true
-           name: BEARER
-   # ...
-   set_cookies:
-       BEARER: ~
+    token_extractors:
+        cookie:
+            enabled: true
+            name: BEARER
+    # ...
+    set_cookies:
+        BEARER: ~
 
-   # Full config with defaults:
-   #  BEARER:
-   #      lifetime: null (defaults to token ttl)
-   #      samesite: lax
-   #      path: /
-   #      domain: null (null means automatically set by symfony)
-   #      secure: true (default to true)
-   #      httpOnly: true
+    # Full config with defaults:
+    #  BEARER:
+    #      lifetime: null (defaults to token ttl)
+    #      samesite: lax
+    #      path: /
+    #      domain: null (null means automatically set by symfony)
+    #      secure: true (default to true)
+    #      httpOnly: true
 
 Automatically generating split cookies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You are also able to automatically generate split cookies. Benefits of
-this approach are in `this
-post <https://medium.com/lightrail/getting-token-authentication-right-in-a-stateless-single-page-application-57d0c6474e3>`__.
+this approach are in
+`this post <https://medium.com/lightrail/getting-token-authentication-right-in-a-stateless-single-page-application-57d0c6474e3>`__.
 
 Set the signature cookie (jwt_s) lifetime to 0 to create session
 cookies.
 
-Keep in mind, that SameSite attribute is **not supported** in `some
-browsers <https://caniuse.com/#feat=same-site-cookie-attribute>`__
+Keep in mind, that SameSite attribute is **not supported** in
+`some browsers <https://caniuse.com/#feat=same-site-cookie-attribute>`__
 
 .. code-block:: yaml
 
-   token_extractors:
-       split_cookie:
-           enabled: true
-           cookies:
-               - jwt_hp
-               - jwt_s
+    token_extractors:
+        split_cookie:
+            enabled: true
+            cookies:
+                - jwt_hp
+                - jwt_s
 
-   set_cookies:
-       jwt_hp:
-           lifetime: null
-           samesite: strict
-           path: /
-           domain: null
-           httpOnly: false
-           split:
-               - header
-               - payload
+    set_cookies:
+        jwt_hp:
+            lifetime: null
+            samesite: strict
+            path: /
+            domain: null
+            httpOnly: false
+            split:
+                - header
+                - payload
 
-       jwt_s:
-           lifetime: 0
-           samesite: strict
-           path: /
-           domain: null
-           httpOnly: true
-           split:
-               - signature
+        jwt_s:
+            lifetime: 0
+            samesite: strict
+            path: /
+            domain: null
+            httpOnly: true
+            split:
+                - signature
 
 Keep the token in the body when using cookies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -188,14 +188,13 @@ Keep the token in the body when using cookies
 When using cookies the response defaults to an empty body and result
 code 204. It is possible to modify this behaviour.
 
-Keep in mind, this invalidates a requirement from the `previously
-mentioned
-post <https://medium.com/lightrail/getting-token-authentication-right-in-a-stateless-single-page-application-57d0c6474e3>`__,
+Keep in mind, this invalidates a requirement from the
+`previously mentioned post <https://medium.com/lightrail/getting-token-authentication-right-in-a-stateless-single-page-application-57d0c6474e3>`__,
 namely "JavaScript/front-end should never have access to the full JWT".
 
-::
+.. code-block:: yaml
 
-   remove_token_from_body_when_cookies_used: false
+    remove_token_from_body_when_cookies_used: false
 
 Security configuration
 ----------------------
@@ -204,41 +203,41 @@ For Symfony 5.3 and higher, use the ``jwt`` authenticator:
 
 .. code-block:: yaml
 
-   # config/packages/security.yaml
-   security:
-       enable_authenticator_manager: true
-       firewalls:
-           api:
-               # ...
-               jwt: ~ # enables the jwt authenticator
+    # config/packages/security.yaml
+    security:
+        enable_authenticator_manager: true
+        firewalls:
+            api:
+                # ...
+                jwt: ~ # enables the jwt authenticator
 
-           # Full config with defaults:
-           #    jwt:
-           #        provider: null  (you can put provider here or just ignore this config)
-           #        authenticator: lexik_jwt_authentication.security.jwt_authenticator (default jwt authenticator)
-           # ...
+            # Full config with defaults:
+            #    jwt:
+            #        provider: null  (you can put provider here or just ignore this config)
+            #        authenticator: lexik_jwt_authentication.security.jwt_authenticator (default jwt authenticator)
+            # ...
 
 For Symfony versions prior to 5.3, use the Guard authenticator:
 
 .. code-block:: yaml
 
-       firewalls:
-           # ...
-           api:
-               # ...
-               guard:
-                   authenticators:
-                       - 'lexik_jwt_authentication.jwt_token_authenticator'
+    firewalls:
+        # ...
+        api:
+            # ...
+            guard:
+                authenticators:
+                    - 'lexik_jwt_authentication.jwt_token_authenticator'
 
 Authenticator
-'''''''''''''
+.............
 
 For more details about using custom authenticator in your application,
-see :doc:`"Extending JWT Authenticator" </6-extending-jwt-authenticator>`.
+see :doc:`Extending JWT Authenticator </6-extending-jwt-authenticator>`.
 
 Database-less User Provider
-'''''''''''''''''''''''''''
+...........................
 
 For a database-less authentication (i.e. trusting into the JWT data
-instead of reloading the user from the database), see :doc:`"A database less
-user provider" </8-jwt-user-provider>`.
+instead of reloading the user from the database), see
+:doc:`"A database less user provider" </8-jwt-user-provider>`.

--- a/Resources/doc/3-functional-testing.rst
+++ b/Resources/doc/3-functional-testing.rst
@@ -6,82 +6,82 @@ Configuration
 
 Generate some test specific keys, for example:
 
-.. code-block:: bash
+.. code-block:: terminal
 
-   $ openssl genrsa -out config/jwt/private-test.pem -aes256 4096
-   $ openssl rsa -pubout -in config/jwt/private-test.pem -out config/jwt/public-test.pem
+    $ openssl genrsa -out config/jwt/private-test.pem -aes256 4096
+    $ openssl rsa -pubout -in config/jwt/private-test.pem -out config/jwt/public-test.pem
 
 Override the bundle configuration in your ``config_test.yml`` :
 
 .. code-block:: yaml
 
-   # config/test/lexik_jwt_authentication.yaml
-   lexik_jwt_authentication:
-       secret_key: '%kernel.project_dir%/config/jwt/private-test.pem'
-       public_key: '%kernel.project_dir%/config/jwt/public-test.pem'
+    # config/test/lexik_jwt_authentication.yaml
+    lexik_jwt_authentication:
+        secret_key: '%kernel.project_dir%/config/jwt/private-test.pem'
+        public_key: '%kernel.project_dir%/config/jwt/public-test.pem'
 
 **Protip:** You might want to commit those keys if you intend to run
-your test on a ci server.
+your test on a CI server.
 
 Usage
 -----
 
-Create an authenticated client :
+Create an authenticated client:
 
 .. code-block:: php
 
-   /**
-    * Create a client with a default Authorization header.
-    *
-    * @param string $username
-    * @param string $password
-    *
-    * @return \Symfony\Bundle\FrameworkBundle\Client
-    */
-   protected function createAuthenticatedClient($username = 'user', $password = 'password')
-   {
-       $client = static::createClient();
-       $client->request(
-         'POST',
-         '/api/login_check',
-         [],
-         [],
-         ['CONTENT_TYPE' => 'application/json'],
-         json_encode([
-           '_username' => $username,
-           '_password' => $password,
-         ])
-       );
+    /**
+     * Create a client with a default Authorization header.
+     *
+     * @param string $username
+     * @param string $password
+     *
+     * @return \Symfony\Bundle\FrameworkBundle\Client
+     */
+    protected function createAuthenticatedClient($username = 'user', $password = 'password')
+    {
+        $client = static::createClient();
+        $client->request(
+          'POST',
+          '/api/login_check',
+          [],
+          [],
+          ['CONTENT_TYPE' => 'application/json'],
+          json_encode([
+            '_username' => $username,
+            '_password' => $password,
+          ])
+        );
 
-       $data = json_decode($client->getResponse()->getContent(), true);
+        $data = json_decode($client->getResponse()->getContent(), true);
 
-       $client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $data['token']));
+        $client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $data['token']));
 
-       return $client;
-   }
+        return $client;
+    }
 
-   /**
-    * test getPagesAction
-    */
-   public function testGetPages()
-   {
-       $client = $this->createAuthenticatedClient();
-       $client->request('GET', '/api/pages');
-       // ... 
-   }
+    /**
+     * test getPagesAction
+     */
+    public function testGetPages()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/api/pages');
+        // ...
+    }
 
 Or manually generate a JWT token for end-to-end testing:
 
 .. code-block:: php
 
-   use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
+    use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
 
-   protected static function createAuthenticatedClient(array $claims)
-   {
-       $client = self::createClient();
-       $encoder = $client->getContainer()->get(JWTEncoderInterface::class);
+    protected static function createAuthenticatedClient(array $claims)
+    {
+        $client = self::createClient();
+        $encoder = $client->getContainer()->get(JWTEncoderInterface::class);
 
-       $client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $encoder->encode($claims)));
+        $client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $encoder->encode($claims)));
 
-       return $client;
-   }
+        return $client;
+    }

--- a/Resources/doc/4-cors-requests.rst
+++ b/Resources/doc/4-cors-requests.rst
@@ -10,18 +10,18 @@ without having to modify your server configuration. See the
 documentation for installation and usage instructions.
 
 Example usage with the LexikJWTAuthenticationBundle
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
-   nelmio_cors:
-       ...
-       paths:
-           '^/api/':
-               allow_origin: ['*']
-               allow_headers: ['*']
-               allow_methods: ['POST', 'PUT', 'GET', 'DELETE']
-               max_age: 3600
+    nelmio_cors:
+        ...
+        paths:
+            '~/api/':
+                allow_origin: ['*']
+                allow_headers: ['*']
+                allow_methods: ['POST', 'PUT', 'GET', 'DELETE']
+                max_age: 3600
 
 The important thing to note here is that both the ``login`` and ``api``
 firewalls paths (in our example ``/api/login_check`` and ``/api``) must

--- a/Resources/doc/5-encoder-service.rst
+++ b/Resources/doc/5-encoder-service.rst
@@ -2,13 +2,11 @@ JWT encoder service customization
 =================================
 
 This bundle comes with two built-in token encoders, one based on the
-```namshi/jose`` <https://github.com/namshi/jose>`__ library (default)
-and the later based on the
-```lcobucci/jwt`` <https://github.com/lcobucci/jwt>`__ library. If both
-don't suit your needs, you can replace it with your own encoder service.
-Here's an example implementing a
-```nixilla/php-jwt`` <https://github.com/nixilla/php-jwt>`__ library
-based encoder.
+`namshi/jose <https://github.com/namshi/jose>`__ library (default) and the later
+based on the `lcobucci/jwt <https://github.com/lcobucci/jwt>`__ library. If both
+don't suit your needs, you can replace it with your own encoder service. Here's
+an example implementing a `nixilla/php-jwt <https://github.com/nixilla/php-jwt>`__
+library based encoder.
 
 Creating your own encoder
 -------------------------
@@ -18,80 +16,82 @@ Create the encoder class
 
 .. code-block:: php
 
-   // src/App/Encoder/NixillaJWTEncoder.php
-   namespace App\Encoder;
+    // src/App/Encoder/NixillaJWTEncoder.php
+    namespace App\Encoder;
 
-   use JWT\Authentication\JWT;
-   use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
-   use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTEncodeFailureException;
-   use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
+    use JWT\Authentication\JWT;
+    use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
+    use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTEncodeFailureException;
+    use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
 
-   /**
-    * NixillaJWTEncoder
-    *
-    * @author Nicolas Cabot <n.cabot@lexik.fr>
-    */
-   class NixillaJWTEncoder implements JWTEncoderInterface
-   {
-       private $key;
+    /**
+     * NixillaJWTEncoder
+     *
+     * @author Nicolas Cabot <n.cabot@lexik.fr>
+     */
+    class NixillaJWTEncoder implements JWTEncoderInterface
+    {
+        private $key;
 
-       public function __construct(string $key = 'super_secret_key')
-       {
-           $this->key = $key;
-       }
+        public function __construct(string $key = 'super_secret_key')
+        {
+            $this->key = $key;
+        }
 
-       /**
-        * {@inheritdoc}
-        */
-       public function encode(array $data)
-       {
-           try {
-               return JWT::encode($data, $this->key);
-           }
-           catch (\Exception $e) {
-               throw new JWTEncodeFailureException(JWTEncodeFailureException::INVALID_CONFIG, 'An error occurred while trying to encode the JWT token.', $e);
-           }
-       }
+        /**
+         * {@inheritdoc}
+         */
+        public function encode(array $data)
+        {
+            try {
+                return JWT::encode($data, $this->key);
+            }
+            catch (\Exception $e) {
+                throw new JWTEncodeFailureException(JWTEncodeFailureException::INVALID_CONFIG, 'An error occurred while trying to encode the JWT token.', $e);
+            }
+        }
 
-       /**
-        * {@inheritdoc}
-        */
-       public function decode($token)
-       {
-           try {
-               return (array) JWT::decode($token, $this->key);
-           } catch (\Exception $e) {
-               throw new JWTDecodeFailureException(JWTDecodeFailureException::INVALID_TOKEN, 'Invalid JWT Token', $e);
-           }
-       }
-   }
+        /**
+         * {@inheritdoc}
+         */
+        public function decode($token)
+        {
+            try {
+                return (array) JWT::decode($token, $this->key);
+            } catch (\Exception $e) {
+                throw new JWTDecodeFailureException(JWTDecodeFailureException::INVALID_TOKEN, 'Invalid JWT Token', $e);
+            }
+        }
+    }
 
 Declare it as a service
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
-   # config/services.yaml
-   services:
-       acme_api.encoder.nixilla_jwt_encoder:
-           class: App\Encoder\NixillaJWTEncoder
+    # config/services.yaml
+    services:
+        acme_api.encoder.nixilla_jwt_encoder:
+            class: App\Encoder\NixillaJWTEncoder
 
 Use it as encoder service
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
-   # config/packages/lexik_jwt_authentication.yaml
-   lexik_jwt_authentication:
-       # ...
-       encoder:
-           service: acme_api.encoder.nixilla_jwt_encoder
+    # config/packages/lexik_jwt_authentication.yaml
+    lexik_jwt_authentication:
+        # ...
+        encoder:
+            service: acme_api.encoder.nixilla_jwt_encoder
 
-| **Note**
-| You can use the ``lexik_jwt_authentication.encoder.crypto_engine`` and
-  ``lexik_jwt_authentication.encoder.signature_algorithm`` parameters
-  that represent the corresponding configuration options by injecting
-  them as argument of the encoder's service, then use them through the
-  library on which the encoder is based on.
-| See the :doc:`configuration reference <1-configuration-reference>` for
-  more informations.
+.. note::
+
+    You can use the ``lexik_jwt_authentication.encoder.crypto_engine`` and
+    ``lexik_jwt_authentication.encoder.signature_algorithm`` parameters
+    that represent the corresponding configuration options by injecting
+    them as argument of the encoder's service, then use them through the
+    library on which the encoder is based on.
+
+    See the :doc:`configuration reference <1-configuration-reference>` for
+    more information.

--- a/Resources/doc/6-extending-jwt-authenticator.rst
+++ b/Resources/doc/6-extending-jwt-authenticator.rst
@@ -1,100 +1,101 @@
 Extending Authenticator
 =======================
 
-The ``JWTTokenAuthenticator`` (Symfony < 5.3) or ``JWTAuthenticator``
-(Symfony >= 5.3) class is responsible of authenticating JWT tokens. It
-is used through the
-``lexik_jwt_authentication.security.guard.jwt_token_authenticator``
-(Symfony < 5.3) or
-``lexik_jwt_authentication.security.jwt_authenticator`` (Symfony >= 5.3)
+The ``JWTTokenAuthenticator`` (Symfony < 5.3) or ``JWTAuthenticator`` (Symfony >= 5.3)
+class is responsible of authenticating JWT tokens. It is used through the
+``lexik_jwt_authentication.security.guard.jwt_token_authenticator`` (Symfony < 5.3)
+or ``lexik_jwt_authentication.security.jwt_authenticator`` (Symfony >= 5.3)
 abstract service which can be customized in the most flexible but still
 structured way to do it: *creating your own authenticators by extending
 the service*, so you can manage various security contexts in the same
 application.
 
-.. creating-your-own-authenticator:
+.. _creating-your-own-authenticator:
 
 Creating your own Authenticator
 -------------------------------
 
-For Symfony versions prior to 5.3:
+For Symfony versions prior to 5.3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: php
 
-   namespace App\Security\Guard;
+    namespace App\Security\Guard;
 
-   use Lexik\Bundle\JWTAuthenticationBundle\Security\Guard\JWTTokenAuthenticator as BaseAuthenticator;
+    use Lexik\Bundle\JWTAuthenticationBundle\Security\Guard\JWTTokenAuthenticator as BaseAuthenticator;
 
-   class JWTTokenAuthenticator extends BaseAuthenticator
-   {
-       // Your own logic
-   }
-
-.. code-block:: yaml
-
-   # config/services.yaml
-   services:
-       app.jwt_token_authenticator:
-           class: App\Security\Guard\JWTTokenAuthenticator
-           parent: lexik_jwt_authentication.security.guard.jwt_token_authenticator
+    class JWTTokenAuthenticator extends BaseAuthenticator
+    {
+        // Your own logic
+    }
 
 .. code-block:: yaml
 
-   # config/packages/security.yaml
-   security:
-       # ...
-       firewalls:
-           # ...
-           api:
-               pattern:   ^/api
-               stateless: true
-               guard: 
-                   authenticators:
-                       - app.jwt_token_authenticator
+    # config/services.yaml
+    services:
+        app.jwt_token_authenticator:
+            class: App\Security\Guard\JWTTokenAuthenticator
+            parent: lexik_jwt_authentication.security.guard.jwt_token_authenticator
 
-For Symfony 5.3 and higher:
+.. code-block:: yaml
+
+    # config/packages/security.yaml
+    security:
+        # ...
+        firewalls:
+            # ...
+            api:
+                pattern:   ~/api
+                stateless: true
+                guard:
+                    authenticators:
+                        - app.jwt_token_authenticator
+
+For Symfony 5.3 and higher
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: php
 
-   namespace App\Security;
+    namespace App\Security;
 
-   use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator;
+    use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator;
 
-   class CustomAuthenticator extends JWTAuthenticator
-   {
-       // Your own logic
-   }
-
-.. code-block:: yaml
-
-   # config/services.yaml
-   services:
-       app.custom_authenticator:
-           class: App\Security\CustomAuthenticator
-           parent: lexik_jwt_authentication.security.jwt_authenticator
+    class CustomAuthenticator extends JWTAuthenticator
+    {
+        // Your own logic
+    }
 
 .. code-block:: yaml
 
-   # config/packages/security.yaml
-   security:
-       # ...
-       firewalls:
-           # ...
-           api:
-               pattern:   ^/api
-               stateless: true
-               jwt: 
-                   authenticator: app.custom_authenticator
+    # config/services.yaml
+    services:
+        app.custom_authenticator:
+            class: App\Security\CustomAuthenticator
+            parent: lexik_jwt_authentication.security.jwt_authenticator
 
-**Note:** The code examples of this section require to have this step
-done, it may not be repeated.
+.. code-block:: yaml
+
+    # config/packages/security.yaml
+    security:
+        # ...
+        firewalls:
+            # ...
+            api:
+                pattern:   ~/api
+                stateless: true
+                jwt:
+                    authenticator: app.custom_authenticator
+
+.. note::
+
+    The code examples of this section require to have this step
+    done, it may not be repeated.
 
 Using different Token Extractors per Authenticator
 --------------------------------------------------
 
 Token extractors are set up in the main configuration of this bundle
-(see :doc:`configuration
-reference </1-configuration-reference>`).
+(see :doc:`configuration reference </1-configuration-reference>`).
 If your application contains multiple firewalls with different security
 contexts, you may want to configure the different token extractors which
 should be used on each firewall respectively. This can be done by having
@@ -105,28 +106,28 @@ You can overwrite the ``getTokenExtractor()`` in custom authenticator:
 
 .. code-block:: php
 
-   /**
-   * @return TokenExtractor\TokenExtractorInterface
-   */
-   protected function getTokenExtractor()
-   {
-       // Return a custom extractor, no matter of what are configured
-       return new TokenExtractor\AuthorizationHeaderTokenExtractor('Token', 'Authorization');
+    /**
+    * @return TokenExtractor\TokenExtractorInterface
+    */
+    protected function getTokenExtractor()
+    {
+        // Return a custom extractor, no matter of what are configured
+        return new TokenExtractor\AuthorizationHeaderTokenExtractor('Token', 'Authorization');
 
-       // Or retrieve the chain token extractor for mapping/unmapping extractors for this authenticator
-       $chainExtractor = parent::getTokenExtractor();
-           
-       // Clear the token extractor map from all configured extractors
-       $chainExtractor->clearMap();
-           
-       // Or only remove a specific extractor
-       $chainTokenExtractor->removeExtractor(function (TokenExtractor\TokenExtractorInterface $extractor) {
-           return $extractor instanceof TokenExtractor\CookieTokenExtractor;
-       });
-           
-       // Add a new query parameter extractor to the configured ones
-       $chainExtractor->addExtractor(new TokenExtractor\QueryParameterTokenExtractor('jwt'));
-           
-       // Return the chain token extractor with the new map
-       return $chainTokenExtractor;
-   }
+        // Or retrieve the chain token extractor for mapping/unmapping extractors for this authenticator
+        $chainExtractor = parent::getTokenExtractor();
+
+        // Clear the token extractor map from all configured extractors
+        $chainExtractor->clearMap();
+
+        // Or only remove a specific extractor
+        $chainTokenExtractor->removeExtractor(function (TokenExtractor\TokenExtractorInterface $extractor) {
+            return $extractor instanceof TokenExtractor\CookieTokenExtractor;
+        });
+
+        // Add a new query parameter extractor to the configured ones
+        $chainExtractor->addExtractor(new TokenExtractor\QueryParameterTokenExtractor('jwt'));
+
+        // Return the chain token extractor with the new map
+        return $chainTokenExtractor;
+    }

--- a/Resources/doc/7-manual-token-creation.rst
+++ b/Resources/doc/7-manual-token-creation.rst
@@ -8,22 +8,22 @@ directly:
 
 .. code-block:: php
 
-   namespace App\Controller;
+    namespace App\Controller;
 
-   use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-   use Symfony\Component\HttpFoundation\JsonResponse;
-   use Symfony\Component\Security\Core\User\UserInterface;
-   use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\HttpFoundation\JsonResponse;
+    use Symfony\Component\Security\Core\User\UserInterface;
+    use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 
-   class ApiController extends Controller
-   {
-       public function getTokenUser(UserInterface $user, JWTTokenManagerInterface $JWTManager)
-       {
-           // ...
+    class ApiController extends Controller
+    {
+        public function getTokenUser(UserInterface $user, JWTTokenManagerInterface $JWTManager)
+        {
+            // ...
 
-           return new JsonResponse(['token' => $JWTManager->create($user)]);
-       }
-   }
+            return new JsonResponse(['token' => $JWTManager->create($user)]);
+        }
+    }
 
 This dispatches the ``Events::JWT_CREATED``, ``Events::JWT_ENCODED``
 events and returns a JWT token, but the
@@ -35,18 +35,18 @@ your login form:
 
 .. code-block:: php
 
-   public function fooAction(UserInterface $user)
-   {    
-       $authenticationSuccessHandler = $this->container->get('lexik_jwt_authentication.handler.authentication_success');
-       
-       return $authenticationSuccessHandler->handleAuthenticationSuccess($user);
-   }
+    public function fooAction(UserInterface $user)
+    {
+        $authenticationSuccessHandler = $this->container->get('lexik_jwt_authentication.handler.authentication_success');
+
+        return $authenticationSuccessHandler->handleAuthenticationSuccess($user);
+    }
 
 You can also pass an existing JWT to the ``handleAuthenticationSuccess``
 method:
 
 .. code-block:: php
 
-   $jwt = $this->container->get('lexik_jwt_authentication.jwt_manager')->create($user);
+    $jwt = $this->container->get('lexik_jwt_authentication.jwt_manager')->create($user);
 
-   return $authenticationSuccessHandler->handleAuthenticationSuccess($user, $jwt);
+    return $authenticationSuccessHandler->handleAuthenticationSuccess($user, $jwt);

--- a/Resources/doc/8-jwt-user-provider.rst
+++ b/Resources/doc/8-jwt-user-provider.rst
@@ -7,11 +7,10 @@ From `jwt.io <https://jwt.io/introduction>`__:
    about the user, avoiding the need to query the database more than
    once. https://jwt.io/introduction
 
-| A JWT is *self-contained*, meaning that we can trust into its payload
-  for processing the authentication. In a nutshell, there should be no
-  need for loading the user from the database when authenticating a JWT
-  Token,
-| the database should be hit only once for delivering the token.
+A JWT is *self-contained*, meaning that we can trust into its payload
+for processing the authentication. In a nutshell, there should be no
+need for loading the user from the database when authenticating a JWT Token,
+the database should be hit only once for delivering the token.
 
 That's why we decided to provide a user provider which is able to create
 User instances from the JWT payload.
@@ -23,32 +22,38 @@ To work, the provider just needs a few lines of configuration:
 
 .. code-block:: yaml
 
-   # config/packages/security.yaml
-   security:
-       providers:
-           jwt:
-               lexik_jwt: ~
+    # config/packages/security.yaml
+    security:
+        providers:
+            jwt:
+                lexik_jwt: ~
 
 Then, use it on your JWT protected firewall:
 
-.. code-block:: yaml
-
-   # Symfony versions prior to 5.3
-   security:
-       firewalls:
-           api:
-               provider: jwt
-               guard:
-                   # ...
+Symfony versions prior to 5.3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
-   # Symfony 5.3 and higher
-   security:
-       firewalls:
-           api:
-               provider: jwt
-               jwt: ~
+    # config/packages/security.yaml
+    security:
+        firewalls:
+            api:
+                provider: jwt
+                guard:
+                    # ...
+
+Symfony 5.3 and higher
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+    # config/packages/security.yaml
+    security:
+        firewalls:
+            api:
+                provider: jwt
+                jwt: ~
 
 What does it change?
 --------------------
@@ -71,46 +76,47 @@ username and the JWT token payload as arguments and returns an instance
 of the class.
 
 Sample implementation
-'''''''''''''''''''''
+---------------------
 
 .. code-block:: php
 
-   namespace App\Security;
+    namespace App\Security;
 
-   final class User implements JWTUserInterface
-   {
-       // Your own logic
-       
-       public function __construct($username, array $roles, $email)
-       {
-           $this->username = $username;
-           $this->roles = $roles;
-           $this->email = $email;
-       }
-       
-       public static function createFromPayload($username, array $payload)
-       {
-           return new self(
-               $username,
-               $payload['roles'], // Added by default
-               $payload['email']  // Custom
-           );
-       }
-   }
+    final class User implements JWTUserInterface
+    {
+        // Your own logic
 
-*Note*: You can extend the default ``JWTUser`` class if that fits your
-needs.
+        public function __construct($username, array $roles, $email)
+        {
+            $this->username = $username;
+            $this->roles = $roles;
+            $this->email = $email;
+        }
+
+        public static function createFromPayload($username, array $payload)
+        {
+            return new self(
+                $username,
+                $payload['roles'], // Added by default
+                $payload['email']  // Custom
+            );
+        }
+    }
+
+.. note::
+
+    You can extend the default ``JWTUser`` class if that fits your needs.
 
 Configuration
-'''''''''''''
+-------------
 
 .. code-block:: yaml
 
-   # config/packages/security.yaml
-   providers:
-       # ...
-       jwt:
-           lexik_jwt:
-               class: App\Security\User
+    # config/packages/security.yaml
+    providers:
+        # ...
+        jwt:
+            lexik_jwt:
+                class: App\Security\User
 
 And voilà!

--- a/Resources/doc/9-access-authenticated-jwt-token.rst
+++ b/Resources/doc/9-access-authenticated-jwt-token.rst
@@ -6,23 +6,21 @@ Service for some purposes, you can:
 
 #. Inject *TokenStorageInterface* and *JWTTokenManagerInterface*:
 
-.. code-block:: php
+   .. code-block:: php
 
-   use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
-   use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+       use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+       use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
-   public function __construct(TokenStorageInterface $tokenStorageInterface, JWTTokenManagerInterface $jwtManager)
-   {
-       $this->jwtManager = $jwtManager;
-       $this->tokenStorageInterface = $tokenStorageInterface;
-   }
+       public function __construct(TokenStorageInterface $tokenStorageInterface, JWTTokenManagerInterface $jwtManager)
+       {
+           $this->jwtManager = $jwtManager;
+           $this->tokenStorageInterface = $tokenStorageInterface;
+       }
 
-#. Call ``decode()`` in jwtManager, and ``getToken()`` in
-   tokenStorageInterface.
+#. Call ``decode()`` in jwtManager, and ``getToken()`` in TokenStorageInterface.
 
-.. code-block:: php
+   .. code-block:: php
 
-   $decodedJwtToken = $this->jwtManager->decode($this->tokenStorageInterface->getToken());
+       $decodedJwtToken = $this->jwtManager->decode($this->tokenStorageInterface->getToken());
 
-This returns the decoded information of the JWT token sent in the
-current request.
+This returns the decoded information of the JWT token sent in the current request.

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -16,12 +16,12 @@ Add
 `lexik/jwt-authentication-bundle <https://packagist.org/packages/lexik/jwt-authentication-bundle>`__
 to your ``composer.json`` file:
 
-.. code-block:: bash
+.. code-block:: terminal
 
-   php composer.phar require "lexik/jwt-authentication-bundle"
+    $ php composer.phar require "lexik/jwt-authentication-bundle"
 
-Register the bundle:
-^^^^^^^^^^^^^^^^^^^^
+Register the bundle
+~~~~~~~~~~~~~~~~~~~
 
 Register bundle into ``config/bundles.php`` (Flex did it automatically):
 
@@ -32,12 +32,12 @@ Register bundle into ``config/bundles.php`` (Flex did it automatically):
        Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
    ];
 
-Generate the SSL keys:
-^^^^^^^^^^^^^^^^^^^^^^
+Generate the SSL keys
+~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: bash
+.. code-block:: terminal
 
-   $ php bin/console lexik:jwt:generate-keypair
+    $ php bin/console lexik:jwt:generate-keypair
 
 Your keys will land in ``config/jwt/private.pem`` and
 ``config/jwt/public.pem`` (unless you configured a different path).
@@ -70,69 +70,80 @@ Configure the SSL keys path and passphrase in your ``.env``:
        pass_phrase: '%env(JWT_PASSPHRASE)%' # required for token creation
        token_ttl: 3600 # in seconds, default is 3600
 
-Configure your ``config/packages/security.yaml`` :
+Configure application security
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Make sure the firewall ``login`` is place before ``api``, and if
-``main`` exists, put it after ``api``, otherwise you will encounter
-``/api/login_check`` route not found.**
+.. caution::
 
-.. code-block:: yaml
+    Make sure the firewall ``login`` is place before ``api``, and if
+    ``main`` exists, put it after ``api``, otherwise you will encounter
+    ``/api/login_check`` route not found.
 
-   # Symfony versions prior to 5.3
-   security:
-       # ...
-       
-       firewalls:
-           login:
-               pattern: ^/api/login
-               stateless: true
-               json_login:
-                   check_path: /api/login_check # or api_login_check as defined in config/routes.yaml
-                   success_handler: lexik_jwt_authentication.handler.authentication_success
-                   failure_handler: lexik_jwt_authentication.handler.authentication_failure
-
-           api:
-               pattern:   ^/api
-               stateless: true
-               guard:
-                   authenticators:
-                       - lexik_jwt_authentication.jwt_token_authenticator
-
-       access_control:
-           - { path: ^/api/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-           - { path: ^/api,       roles: IS_AUTHENTICATED_FULLY }
+Symfony versions prior to 5.3
+.............................
 
 .. code-block:: yaml
 
-   # Symfony 5.3 and higher
-   security:
-       enable_authenticator_manager: true
-       # ...
-       
-       firewalls:
-           login:
-               pattern: ^/api/login
-               stateless: true
-               json_login:
-                   check_path: /api/login_check
-                   success_handler: lexik_jwt_authentication.handler.authentication_success
-                   failure_handler: lexik_jwt_authentication.handler.authentication_failure
+    # config/packages/security.yaml
+    security:
+        # ...
 
-           api:
-               pattern:   ^/api
-               stateless: true
-               jwt: ~
+        firewalls:
+            login:
+                pattern: ~/api/login
+                stateless: true
+                json_login:
+                    check_path: /api/login_check # or api_login_check as defined in config/routes.yaml
+                    success_handler: lexik_jwt_authentication.handler.authentication_success
+                    failure_handler: lexik_jwt_authentication.handler.authentication_failure
 
-       access_control:
-           - { path: ^/api/login, roles: PUBLIC_ACCESS }
-           - { path: ^/api,       roles: IS_AUTHENTICATED_FULLY }
+            api:
+                pattern:   ~/api
+                stateless: true
+                guard:
+                    authenticators:
+                        - lexik_jwt_authentication.jwt_token_authenticator
 
-Configure your routing into ``config/routes.yaml`` :
+        access_control:
+            - { path: ~/api/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+            - { path: ~/api,       roles: IS_AUTHENTICATED_FULLY }
+
+Symfony 5.3 and higher
+......................
 
 .. code-block:: yaml
 
-   api_login_check:
-       path: /api/login_check
+    # config/packages/security.yaml
+    security:
+        enable_authenticator_manager: true
+        # ...
+
+        firewalls:
+            login:
+                pattern: ~/api/login
+                stateless: true
+                json_login:
+                    check_path: /api/login_check
+                    success_handler: lexik_jwt_authentication.handler.authentication_success
+                    failure_handler: lexik_jwt_authentication.handler.authentication_failure
+
+            api:
+                pattern:   ~/api
+                stateless: true
+                jwt: ~
+
+        access_control:
+            - { path: ~/api/login, roles: PUBLIC_ACCESS }
+            - { path: ~/api,       roles: IS_AUTHENTICATED_FULLY }
+
+Configure application routing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+    # config/routes.yaml
+    api_login_check:
+        path: /api/login_check
 
 Usage
 -----
@@ -143,31 +154,30 @@ Usage
 ~~~~~~~~~~~~~~~~~~~
 
 The first step is to authenticate the user using its credentials.
-
 You can test getting the token with a simple curl command like this
 (adapt host and port):
 
-Linux or macOS
+Linux or macOS:
+
+.. code-block:: terminal
+
+    $ curl -X POST -H "Content-Type: application/json" https://localhost/api/login_check -d '{"username":"johndoe","password":"test"}'
+
+Windows:
 
 .. code-block:: bash
 
-   curl -X POST -H "Content-Type: application/json" https://localhost/api/login_check -d '{"username":"johndoe","password":"test"}'
-
-Windows
-
-.. code-block:: bash
-
-   curl -X POST -H "Content-Type: application/json" https://localhost/api/login_check --data {\"username\":\"johndoe\",\"password\":\"test\"}
+    C:\> curl -X POST -H "Content-Type: application/json" https://localhost/api/login_check --data {\"username\":\"johndoe\",\"password\":\"test\"}
 
 If it works, you will receive something like this:
 
 .. code-block:: json
 
-   {
-      "token" : "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXUyJ9.eyJleHAiOjE0MzQ3Mjc1MzYsInVzZXJuYW1lIjoia29ybGVvbiIsImlhdCI6IjE0MzQ2NDExMzYifQ.nh0L_wuJy6ZKIQWh6OrW5hdLkviTs1_bau2GqYdDCB0Yqy_RplkFghsuqMpsFls8zKEErdX5TYCOR7muX0aQvQxGQ4mpBkvMDhJ4-pE4ct2obeMTr_s4X8nC00rBYPofrOONUOR4utbzvbd4d2xT_tj4TdR_0tsr91Y7VskCRFnoXAnNT-qQb7ci7HIBTbutb9zVStOFejrb4aLbr7Fl4byeIEYgp2Gd7gY"
-   }
+    {
+        "token" : "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXUyJ9.eyJleHAiOjE0MzQ3Mjc1MzYsInVzZXJuYW1lIjoia29ybGVvbiIsImlhdCI6IjE0MzQ2NDExMzYifQ.nh0L_wuJy6ZKIQWh6OrW5hdLkviTs1_bau2GqYdDCB0Yqy_RplkFghsuqMpsFls8zKEErdX5TYCOR7muX0aQvQxGQ4mpBkvMDhJ4-pE4ct2obeMTr_s4X8nC00rBYPofrOONUOR4utbzvbd4d2xT_tj4TdR_0tsr91Y7VskCRFnoXAnNT-qQb7ci7HIBTbutb9zVStOFejrb4aLbr7Fl4byeIEYgp2Gd7gY"
+    }
 
-Store it (client side), the JWT is reusable until its ttl has expired
+Store it (client side), the JWT is reusable until its TTL has expired
 (3600 seconds by default).
 
 .. _2-use-the-token:
@@ -185,7 +195,8 @@ See the :doc:`configuration reference </1-configuration-reference>` document
 to enable query string parameter mode or change the header value prefix.
 
 Examples
-^^^^^^^^
+~~~~~~~~
+
 See :doc:`Functionally testing a JWT protected
 api </3-functional-testing>` document or the sandbox application
 `Symfony4 <https://github.com/chalasr/lexik-jwt-authentication-sandbox>`__)
@@ -195,7 +206,7 @@ Notes
 -----
 
 About token expiration
-^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~
 
 Each request after token expiration will result in a 401 response. Redo
 the authentication process to obtain a new token.
@@ -205,20 +216,19 @@ case you can check
 `JWTRefreshTokenBundle <https://github.com/gesdinet/JWTRefreshTokenBundle>`__.
 
 Working with CORS requests
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is more of a Symfony2 related topic, but see `Working with CORS
-requests <4-cors-requests>`__ document to get a quick explanation on
-handling CORS requests.
+This is more of a Symfony2 related topic, but see :doc:`Working with CORS requests </4-cors-requests>`
+document to get a quick explanation on handling CORS requests.
 
 Impersonation
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~
 
 For impersonating users using JWT, see
 https://symfony.com/doc/current/security/impersonating_user.html
 
 Important note for Apache users
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As stated in `this
 link <https://stackoverflow.com/questions/11990388/request-headers-bag-is-missing-authorization-header-in-symfony-2>`__
@@ -232,7 +242,7 @@ you should), please add those rules to your VirtualHost configuration :
 
 .. code-block:: apache
 
-   SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 
 Further documentation
 ---------------------
@@ -241,12 +251,10 @@ The following documents are available:
 
 -  :doc:`Configuration reference </1-configuration-reference>`
 -  :doc:`Data customization and validation </2-data-customization>`
--  :doc:`Functionally testing a JWT protected
-   api </3-functional-testing>`
+-  :doc:`Functionally testing a JWT protected api </3-functional-testing>`
 -  :doc:`Working with CORS requests </4-cors-requests>`
 -  :doc:`JWT encoder service customization </5-encoder-service>`
 -  :doc:`Extending Authenticator </6-extending-jwt-authenticator>`
 -  :doc:`Creating JWT tokens programmatically </7-manual-token-creation>`
 -  :doc:`A database-less user provider </8-jwt-user-provider>`
--  :doc:`Accessing the authenticated JWT
-   token </9-access-authenticated-jwt-token>`
+-  :doc:`Accessing the authenticated JWT token </9-access-authenticated-jwt-token>`


### PR DESCRIPTION
This PR includes the following:

* Some minor formatting and typo fixes
* Change the `<h3>` underline to `~~~` instead of `^^^` to comply with Symfony Docs practices
* Change the `<h4>` underline to `...` instead of `'''` to comply with Symfony Docs practices
* Reindent all code blocks (they used 3 white spaces but we need 4)
* Use `code-block:: terminal` instead of `code-block:: bash` when we want to display some console command
* Use `.. note::` and `.. caution::` admonitions
* Fix the syntax of some internal references
* Display the "Before Symfony 5.3" and "When using Symfony 5.3 or higher" texts as headings to not confuse readers
