### PR TITLE
[Doc] Add the bundle config for Symfony Docs

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,0 +1,6 @@
+branches: ['1.x', '2.x']
+maintained_branches: ['2.x']
+current_branch: "2.x"
+dev_branch: "2.x"
+doc_dir: 'Resources/doc/'
+dev_branch_alias: '2.x'


### PR DESCRIPTION
We need this config file for the integration of the docs on symfony.com. Please, review that the branches and their aliases are correct. Thanks!