### PR TITLE
Fix ECDSA algo names in LcobucciJWSProvider

### DIFF
--- a/Services/JWSProvider/LcobucciJWSProvider.php
+++ b/Services/JWSProvider/LcobucciJWSProvider.php
@@ -178,9 +178,9 @@ class LcobucciJWSProvider implements JWSProviderInterface
             'RS256' => Signer\Rsa\Sha256::class,
             'RS384' => Signer\Rsa\Sha384::class,
             'RS512' => Signer\Rsa\Sha512::class,
-            'EC256' => Signer\Ecdsa\Sha256::class,
-            'EC384' => Signer\Ecdsa\Sha384::class,
-            'EC512' => Signer\Ecdsa\Sha512::class,
+            'ES256' => Signer\Ecdsa\Sha256::class,
+            'ES384' => Signer\Ecdsa\Sha384::class,
+            'ES512' => Signer\Ecdsa\Sha512::class,
         ];
 
         if (!isset($signerMap[$signatureAlgorithm])) {

--- a/Tests/Services/JWSProvider/LcobucciJWSProviderTest.php
+++ b/Tests/Services/JWSProvider/LcobucciJWSProviderTest.php
@@ -85,7 +85,7 @@ rT9kcwLvwUGRmm5HVAz06a9t6gOj0pvoR2oOn9GS7zWCxd3f8vL7nA==
             ->willReturn('foobar');
 
         $payload     = ['username' => 'chalasr'];
-        $jwsProvider = new LcobucciJWSProvider($keyLoaderMock, 'openssl', 'EC512', 3600, 0);
+        $jwsProvider = new LcobucciJWSProvider($keyLoaderMock, 'openssl', 'ES512', 3600, 0);
 
         $this->assertInstanceOf(CreatedJWS::class, $created = $jwsProvider->create($payload));
 


### PR DESCRIPTION
Hi,

While trying to use ECDSA signature, I encountered `The algorithm "ES256" is not supported by Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\LcobucciJWSProvider`.

This name mismatch is pretty clear observing the `GenerateKeyPairCommand` command, which defines `ES256`, `ES384` and `ES512`  in its `ACCEPTED_ALGORITHMS` constant.

This PR fixes this issue and allows usage of ESxxx algorithms.