### PR TITLE
Fix lexik#944: Separate CompatFailureResponse from FailureResponse

### DIFF
--- a/Response/JWTAuthenticationFailureResponse.php
+++ b/Response/JWTAuthenticationFailureResponse.php
@@ -4,54 +4,6 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Response;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
 
-if (80000 <= \PHP_VERSION_ID && (new \ReflectionMethod(JsonResponse::class, 'setData'))->hasReturnType()) {
-    eval('
-        namespace Lexik\Bundle\JWTAuthenticationBundle\Response;
-
-        use Symfony\Component\HttpFoundation\JsonResponse;
-
-        /**
-         * Compatibility layer for Symfony 6.0 and later.
-         *
-         * @internal
-         */
-        abstract class JWTCompatAuthenticationFailureResponse extends JsonResponse
-        {
-            /**
-             * Sets the response data with the statusCode & message included.
-             *
-             * {@inheritdoc}
-             *
-             * @return static
-             */
-            public function setData($data = []): static
-            {
-                return parent::setData((array) $data + ["code" => $this->statusCode, "message" => $this->getMessage()]);
-            }
-        }
-    ');
-} else {
-    /**
-     * Compatibility layer for Symfony 5.4 and earlier.
-     *
-     * @internal
-     */
-    abstract class JWTCompatAuthenticationFailureResponse extends JsonResponse
-    {
-        /**
-         * Sets the response data with the statusCode & message included.
-         *
-         * {@inheritdoc}
-         *
-         * @return static
-         */
-        public function setData($data = [])
-        {
-            return parent::setData((array) $data + ['code' => $this->statusCode, 'message' => $this->getMessage()]);
-        }
-    }
-}
-
 /**
  * JWTAuthenticationFailureResponse.
  *

--- a/Response/JWTCompatAuthenticationFailureResponse.php
+++ b/Response/JWTCompatAuthenticationFailureResponse.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Response;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * The "AND" in the if statement is a temporary fix for the following issue:
+ * https://github.com/lexik/LexikJWTAuthenticationBundle/issues/944
+ * https://github.com/vimeo/psalm/issues/7923
+ */
+if (80000 <= \PHP_VERSION_ID AND (new \ReflectionMethod(JsonResponse::class, 'setData'))->hasReturnType()) {
+    eval('
+        namespace Lexik\Bundle\JWTAuthenticationBundle\Response;
+        
+        use Symfony\Component\HttpFoundation\JsonResponse;
+
+        /**
+         * Compatibility layer for Symfony 6.0 and later.
+         *
+         * @internal
+         */
+        abstract class JWTCompatAuthenticationFailureResponse extends JsonResponse
+        {
+            /**
+             * Sets the response data with the statusCode & message included.
+             *
+             * {@inheritdoc}
+             *
+             * @return static
+             */
+            public function setData($data = []): static
+            {
+                return parent::setData((array)$data + ["code" => $this->statusCode, "message" => $this->getMessage()]);
+            }
+        }
+    ');
+} else {
+    /**
+     * Compatibility layer for Symfony 5.4 and earlier.
+     *
+     * @internal
+     */
+    abstract class JWTCompatAuthenticationFailureResponse extends JsonResponse
+    {
+        /**
+         * Sets the response data with the statusCode & message included.
+         *
+         * {@inheritdoc}
+         *
+         * @return static
+         */
+        public function setData($data = [])
+        {
+            return parent::setData((array)$data + ['code' => $this->statusCode, 'message' => $this->getMessage()]);
+        }
+    }
+}


### PR DESCRIPTION
Hello,

Following ondrejmirtes' feedback on issue #944, here is a little fix that might do the trick.

It seems that just separating the classes is not enough for psalm, and that you have to blow up the eval(), which doesn't seem to me to bring any particular difficulty?

update: Oh my bad, it makes the tests fail in 7.1 & 7.4