### PR TITLE
[Doc] Replace tilde in paths with carets

### DIFF
--- a/Resources/doc/4-cors-requests.rst
+++ b/Resources/doc/4-cors-requests.rst
@@ -17,7 +17,7 @@ Example usage with the LexikJWTAuthenticationBundle
     nelmio_cors:
         ...
         paths:
-            '~/api/':
+            '^/api/':
                 allow_origin: ['*']
                 allow_headers: ['*']
                 allow_methods: ['POST', 'PUT', 'GET', 'DELETE']

--- a/Resources/doc/6-extending-jwt-authenticator.rst
+++ b/Resources/doc/6-extending-jwt-authenticator.rst
@@ -45,7 +45,7 @@ For Symfony versions prior to 5.3
         firewalls:
             # ...
             api:
-                pattern:   ~/api
+                pattern:   ^/api
                 stateless: true
                 guard:
                     authenticators:
@@ -81,7 +81,7 @@ For Symfony 5.3 and higher
         firewalls:
             # ...
             api:
-                pattern:   ~/api
+                pattern:   ^/api
                 stateless: true
                 jwt:
                     authenticator: app.custom_authenticator

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -90,7 +90,7 @@ Symfony versions prior to 5.3
 
         firewalls:
             login:
-                pattern: ~/api/login
+                pattern: ^/api/login
                 stateless: true
                 json_login:
                     check_path: /api/login_check # or api_login_check as defined in config/routes.yaml
@@ -98,15 +98,15 @@ Symfony versions prior to 5.3
                     failure_handler: lexik_jwt_authentication.handler.authentication_failure
 
             api:
-                pattern:   ~/api
+                pattern:   ^/api
                 stateless: true
                 guard:
                     authenticators:
                         - lexik_jwt_authentication.jwt_token_authenticator
 
         access_control:
-            - { path: ~/api/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-            - { path: ~/api,       roles: IS_AUTHENTICATED_FULLY }
+            - { path: ^/api/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+            - { path: ^/api,       roles: IS_AUTHENTICATED_FULLY }
 
 Symfony 5.3 and higher
 ......................
@@ -120,7 +120,7 @@ Symfony 5.3 and higher
 
         firewalls:
             login:
-                pattern: ~/api/login
+                pattern: ^/api/login
                 stateless: true
                 json_login:
                     check_path: /api/login_check
@@ -128,13 +128,13 @@ Symfony 5.3 and higher
                     failure_handler: lexik_jwt_authentication.handler.authentication_failure
 
             api:
-                pattern:   ~/api
+                pattern:   ^/api
                 stateless: true
                 jwt: ~
 
         access_control:
-            - { path: ~/api/login, roles: PUBLIC_ACCESS }
-            - { path: ~/api,       roles: IS_AUTHENTICATED_FULLY }
+            - { path: ^/api/login, roles: PUBLIC_ACCESS }
+            - { path: ^/api,       roles: IS_AUTHENTICATED_FULLY }
 
 Configure application routing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The paths started with a tilde, which doesn't seem to make sense. I think they were changed to tilde by mistake, so I've replaced them by carets again.