### PR TITLE
Fix deprecation message

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -79,7 +79,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->scalarNode('user_identity_field')
-                    ->setDeprecated(...$this->getDeprecationParameters('The "%path%.%node%" configuration key is deprecated since version 2.15, implement "' . UserInterface::class . '::getUserIdentifier()" instead.', '2.5'))
+                    ->setDeprecated(...$this->getDeprecationParameters('The "%path%.%node%" configuration key is deprecated since version 2.16, implement "' . UserInterface::class . '::getUserIdentifier()" instead.', '2.16'))
                     ->defaultValue('username')
                     ->cannotBeEmpty()
                 ->end()


### PR DESCRIPTION
Right now, the message this is generating says `Since lexik/jwt-authentication-bundle 2.5: [snip] since version 2.15`, clearly showing two different versions.  The deprecation actually landed in 2.16, so this updates the message to use a single (and consistent) version number.