### PR TITLE
SF6.2 Access Token Support

### DIFF
--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -13,6 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 
 /**
  * This is the class that loads and manages your bundle configuration.
@@ -44,6 +45,9 @@ class LexikJWTAuthenticationExtension extends Extension
         $loader->load('token_authenticator.xml');
         $loader->load('token_extractor.xml');
         $loader->load('guard_authenticator.xml');
+        if (interface_exists(AccessTokenHandlerInterface::class)) {
+            $loader->load('access_token_handler.xml');
+        }
 
         if (isset($config['private_key_path'])) {
             $config['secret_key'] = $config['private_key_path'];

--- a/Resources/config/access_token_handler.xml
+++ b/Resources/config/access_token_handler.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="lexik_jwt_authentication.security.access_token_handler" class="Lexik\Bundle\JWTAuthenticationBundle\Security\AccessToken\JWTHandler">
+            <argument type="service" id="lexik_jwt_authentication.jwt_manager"/>
+        </service>
+    </services>
+</container>

--- a/Security/AccessToken/JWTHandler.php
+++ b/Security/AccessToken/JWTHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Security\AccessToken;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
+
+/**
+ * @final
+ */
+class JWTHandler implements AccessTokenHandlerInterface
+{
+    /**
+     * @var JWTTokenManagerInterface
+     */
+    private $jwtManager;
+
+    public function __construct(
+        JWTTokenManagerInterface $jwtManager
+    )
+    {
+        $this->jwtManager = $jwtManager;
+    }
+
+    public function getUserIdentifierFrom(string $accessToken): string
+    {
+
+        try {
+            if (!$payload = $this->jwtManager->parse($accessToken)) {
+                throw new AuthenticationException('Invalid JWT Token');
+            }
+        } catch (\Throwable $e) {
+            throw new AuthenticationException('Invalid JWT Token', 0, $e);
+        }
+
+        $idClaim = $this->jwtManager->getUserIdClaim();
+        if (!isset($payload[$idClaim])) {
+            throw new AuthenticationException(sprintf('Unable to find key "%s" in the token payload.', $idClaim));
+        }
+        if (!is_string($payload[$idClaim]) || $payload[$idClaim] === '') {
+            throw new AuthenticationException(sprintf('Invalid key "%s" in the token payload.', $idClaim));
+        }
+
+        return $payload[$idClaim];
+    }
+}


### PR DESCRIPTION
This PR provides an Access Token Handler that can be used with the new SF6.2 access token security provider(see https://github.com/symfony/symfony/pull/46428).

* [x] New service
* [x] Adaptative loading depending on the SF version
* [ ] Documentation
* [ ] Tests

> **Note**
> I am not sure how to create functional tests for this PR. Help welcomed!