### PR TITLE
Fixes TypeError in JWTManager

### DIFF
--- a/Security/Authenticator/JWTAuthenticator.php
+++ b/Security/Authenticator/JWTAuthenticator.php
@@ -105,7 +105,7 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
     {
         $token = $this->getTokenExtractor()->extract($request);
         if ($token === false) {
-            throw new InvalidTokenException('Unable to extract JWT token');
+            throw new \LogicException('Unable to extract a JWT token from the request. Also, make sure to call `supports()` before `authenticate()` to get a proper client error.');
         }
 
         try {

--- a/Security/Authenticator/JWTAuthenticator.php
+++ b/Security/Authenticator/JWTAuthenticator.php
@@ -104,6 +104,9 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
     public function doAuthenticate(Request $request) /*: Passport */
     {
         $token = $this->getTokenExtractor()->extract($request);
+        if ($token === false) {
+            throw new InvalidTokenException('Unable to extract JWT token');
+        }
 
         try {
             if (!$payload = $this->jwtManager->parse($token)) {

--- a/Tests/Security/Authenticator/JWTAuthenticatorTest.php
+++ b/Tests/Security/Authenticator/JWTAuthenticatorTest.php
@@ -307,6 +307,24 @@ class JWTAuthenticatorTest extends TestCase
         $this->assertSame('dummytoken', $token->getCredentials());
     }
 
+    public function testParsingAnInvalidTokenThrowsException()
+    {
+        $jwtManager = $this->getJWTManagerMock();
+        $jwtManager->method('parse')
+            ->willThrowException(new InvalidTokenException('Unable to extract JWT token'));
+
+        $authenticator = new JWTAuthenticator(
+            $jwtManager,
+            $this->getEventDispatcherMock(),
+            $this->getTokenExtractorMock(false),
+            $this->getUserProviderMock()
+        );
+
+        $this->expectException(InvalidTokenException::class);
+
+        $authenticator->authenticate($this->getRequestMock());
+    }
+
     private function getJWTManagerMock($userIdentityField = null, $userIdClaim = null)
     {
         $jwtManager = $this->getMockBuilder(DummyJWTManager::class)

--- a/Tests/Security/Authenticator/JWTAuthenticatorTest.php
+++ b/Tests/Security/Authenticator/JWTAuthenticatorTest.php
@@ -320,7 +320,7 @@ class JWTAuthenticatorTest extends TestCase
             $this->getUserProviderMock()
         );
 
-        $this->expectException(InvalidTokenException::class);
+        $this->expectException(\LogicException::class);
 
         $authenticator->authenticate($this->getRequestMock());
     }


### PR DESCRIPTION
When the TokenExtractor extracts a token, it will return
`string|false`.  The JWTAuthenticator then passes this value to
`JWTManager::doAuthenticate` which can only accept a string.  If a false
is returned by the TokenExtractor, PHP throws a type error.  This commit
checks the return value and throws an exception if it returns false.

Issue: #1066