### PR TITLE
Update link to refresh token bundle

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -213,7 +213,7 @@ the authentication process to obtain a new token.
 
 Maybe you want to use a **refresh token** to renew your JWT. In this
 case you can check
-`JWTRefreshTokenBundle <https://github.com/gesdinet/JWTRefreshTokenBundle>`__.
+`JWTRefreshTokenBundle <https://github.com/markitosgv/JWTRefreshTokenBundle>`__.
 
 Working with CORS requests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Well, the old link was correctly redirected to the new repository. But let's fix it before the redirection ends :) .