### PR TITLE
Fixed: Compatibility to php8.1

### DIFF
--- a/Security/Authenticator/ForwardCompatAuthenticatorTrait.php
+++ b/Security/Authenticator/ForwardCompatAuthenticatorTrait.php
@@ -21,7 +21,7 @@ if ($r->hasReturnType() && Passport::class === $r->getReturnType()->getName()) {
          */
         trait ForwardCompatAuthenticatorTrait
         {
-            public function authenticate(Request $request): Passport
+            public function authenticate(?Request $request = null): Passport
             {
                 return $this->doAuthenticate($request);
             }
@@ -33,7 +33,7 @@ if ($r->hasReturnType() && Passport::class === $r->getReturnType()->getName()) {
      */
     trait ForwardCompatAuthenticatorTrait
     {
-        public function authenticate(Request $request): PassportInterface
+        public function authenticate(?Request $request = null): PassportInterface
         {
             return $this->doAuthenticate($request);
         }

--- a/Security/Authenticator/JWTAuthenticator.php
+++ b/Security/Authenticator/JWTAuthenticator.php
@@ -93,7 +93,7 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
         return $event->getResponse();
     }
 
-    public function supports(Request $request): ?bool
+    public function supports(?Request $request = null): ?bool
     {
         return false !== $this->getTokenExtractor()->extract($request);
     }
@@ -101,7 +101,7 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
     /**
      * @return Passport
      */
-    public function doAuthenticate(Request $request) /*: Passport */
+    public function doAuthenticate(?Request $request = null) /*: Passport */
     {
         $token = $this->getTokenExtractor()->extract($request);
         if ($token === false) {


### PR DESCRIPTION
Running my application under php8.1, I get following error:
` Fatal error: Declaration of Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator::supports(Symfony\Component\HttpFoundation\Request $request): ?bool must be compatible with Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface::supports(?Symfony\Component\HttpFoundation\Request $request = null): ?bool in /srv/app/vendor/lexik/jwt-authentication-bundle/Security/Authenticator/JWTAuthenticator.php on line 96`

Same issue with ForwardCompatAuthenticatorTrait.php