### PR TITLE
allow environment variables for `remove_token_from_body_when_cookies_used`

### DIFF
--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -102,10 +102,10 @@ class LexikJWTAuthenticationExtension extends Extension
             ->getDefinition('lexik_jwt_authentication.extractor.chain_extractor')
             ->replaceArgument(0, $tokenExtractors);
 
-        if (false === $config['remove_token_from_body_when_cookies_used']) {
+        if (isset($config['remove_token_from_body_when_cookies_used'])) {
             $container
                 ->getDefinition('lexik_jwt_authentication.handler.authentication_success')
-                ->replaceArgument(3, false);
+                ->replaceArgument(3, $config['remove_token_from_body_when_cookies_used']);
         }
 
         if ($config['set_cookies']) {


### PR DESCRIPTION
https://github.com/lexik/LexikJWTAuthenticationBundle/pull/940 introduced a new config option to enable response body when cookies are used:

```yaml
remove_token_from_body_when_cookies_used: false
```

However, currently environment variables cannot be used to control this config. An error `Environment variables "bool:JWT_REMOVE_TOKEN_FROM_BODY" are never used` is thrown. After this PR, this option can also be used as following:

```yaml
remove_token_from_body_when_cookies_used: '%env(bool:JWT_REMOVE_TOKEN_FROM_BODY)%'
```