### PR TITLE
Fixed: Allow expiration never (ttl = 0)

### DIFF
--- a/Signature/LoadedJWS.php
+++ b/Signature/LoadedJWS.php
@@ -68,7 +68,11 @@ final class LoadedJWS
             return;
         }
 
-        if (!isset($this->payload['exp']) || !is_numeric($this->payload['exp'])) {
+        if(!isset($this->payload['exp'])) {
+            return;
+        }
+
+        if (!is_numeric($this->payload['exp'])) {
             $this->state = self::INVALID;
 
             return;


### PR DESCRIPTION
Setting `$payload['exp'] = 0;` in JWT_CREATED event, the exp entry is removed correctly from payload, but the validation of token is always returning invalid. If no exp is defined, the exp is unlimited by jwt-standard. This PR should fix it.