### PR TITLE
Fix creation of dynamic property

### DIFF
--- a/Event/AuthenticationFailureEvent.php
+++ b/Event/AuthenticationFailureEvent.php
@@ -28,7 +28,7 @@ class AuthenticationFailureEvent extends Event
     /**
      * @var Request|null
      */
-    private $request;
+    protected $request;
 
     public function __construct(?AuthenticationException $exception, ?Response $response, ?Request $request = null)
     {


### PR DESCRIPTION
Fixes the deprecation for PHP 8.2:

```
PHP Deprecated:  Creation of dynamic property Lexik\Bundle\JWTAuthenticationBundle\Event\JWTNotFoundEvent::$request is deprecated in vendor/lexik/jwt-authentication-bundle/Event/JWTNotFoundEvent.php on line 20
```

In `JWTNotFoundEvent::__construct()` the property `request` is written but in parent class it is private.