### PR TITLE
Use the Security domain for translated messages

### DIFF
--- a/Security/Authenticator/JWTAuthenticator.php
+++ b/Security/Authenticator/JWTAuthenticator.php
@@ -149,7 +149,7 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
     {
         $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());
         if (null !== $this->translator) {
-            $errorMessage = $this->translator->trans($exception->getMessageKey(), $exception->getMessageData());
+            $errorMessage = $this->translator->trans($exception->getMessageKey(), $exception->getMessageData(), 'security');
         }
         $response = new JWTAuthenticationFailureResponse($errorMessage);
 

--- a/Security/Guard/JWTTokenAuthenticator.php
+++ b/Security/Guard/JWTTokenAuthenticator.php
@@ -168,7 +168,7 @@ class JWTTokenAuthenticator implements AuthenticatorInterface
     {
         $errorMessage = strtr($authException->getMessageKey(), $authException->getMessageData());
         if (null !== $this->translator) {
-            $errorMessage = $this->translator->trans($authException->getMessageKey(), $authException->getMessageData());
+            $errorMessage = $this->translator->trans($authException->getMessageKey(), $authException->getMessageData(), 'security');
         }
         $response = new JWTAuthenticationFailureResponse($errorMessage);
 


### PR DESCRIPTION
By default, the translation keys related to security are stored in the `security` domain.

The AuthenticationFailureHandler use this domain:

https://github.com/lexik/LexikJWTAuthenticationBundle/blob/2.x/Security/Http/Authentication/AuthenticationFailureHandler.php#L46

But these 2 authenticators don't use the right domain.