### PR TITLE
Fix ci 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
             matrix:
                 include:
                     # Lowest Deps
-                    - php: 7.1
-                      symfony: 4.4.*
+                    - php: 7.2
+                      symfony: 5.4.*
                       composer-flags: '--prefer-stable --prefer-lowest'
                       can-fail: false
                     # LTS with latest stable PHP

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -36,4 +36,3 @@ jobs:
             - name: CONDING STANDARDS (RECTOR)
               run: |
                   vendor/bin/rector process --ansi --dry-run --xdebug
-

--- a/Command/GenerateTokenCommand.php
+++ b/Command/GenerateTokenCommand.php
@@ -91,7 +91,7 @@ class GenerateTokenCommand extends Command
         }
 
         $payload = [];
-        
+
         if (null !== $input->getOption('ttl') && ((int) $input->getOption('ttl')) == 0) {
             $payload['exp'] = 0;
         } elseif (null !== $input->getOption('ttl') && ((int) $input->getOption('ttl')) > 0) {

--- a/Services/JWSProvider/LcobucciJWSProvider.php
+++ b/Services/JWSProvider/LcobucciJWSProvider.php
@@ -23,6 +23,7 @@ use Lcobucci\JWT\Token\Plain;
 use Lcobucci\JWT\Token\RegisteredClaims;
 use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Lcobucci\JWT\Validation\Constraint\ValidAt;
 use Lcobucci\JWT\Validation\Validator;
 use Lcobucci\JWT\ValidationData;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\KeyLoaderInterface;
@@ -259,10 +260,11 @@ class LcobucciJWSProvider implements JWSProviderInterface
         }
 
         $validator = new Validator();
+        $classValidator = class_exists(LooseValidAt::class) ? LooseValidAt::class : ValidAt::class;
 
         $isValid = $validator->validate(
             $jwt,
-            new LooseValidAt($this->clock, new \DateInterval("PT{$this->clockSkew}S")),
+            new $classValidator($this->clock, new \DateInterval("PT{$this->clockSkew}S")),
             new SignedWith($this->signer, $key)
         );
 
@@ -275,7 +277,7 @@ class LcobucciJWSProvider implements JWSProviderInterface
         foreach ($publicKeys as $key) {
             $isValid = $validator->validate(
                 $jwt,
-                new LooseValidAt($this->clock, new \DateInterval("PT{$this->clockSkew}S")),
+                new $classValidator($this->clock, new \DateInterval("PT{$this->clockSkew}S")),
                 new SignedWith($this->signer, InMemory::plainText($key))
             );
 

--- a/Tests/Functional/CompleteTokenAuthenticationTest.php
+++ b/Tests/Functional/CompleteTokenAuthenticationTest.php
@@ -59,7 +59,7 @@ class CompleteTokenAuthenticationTest extends TestCase
 
     public function testAccessSecuredRouteWithInvalidToken($token = 'dummy')
     {
-        static::$client->request('GET', '/api/secured', [], [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::$client->jsonRequest('GET', '/api/secured', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
 
         $response = static::$client->getResponse();
 
@@ -129,6 +129,6 @@ class CompleteTokenAuthenticationTest extends TestCase
 
     protected function accessSecuredRoute()
     {
-        static::$client->request('GET', '/api/secured');
+        static::$client->jsonRequest('GET', '/api/secured');
     }
 }

--- a/Tests/Functional/GetTokenTest.php
+++ b/Tests/Functional/GetTokenTest.php
@@ -18,7 +18,7 @@ class GetTokenTest extends TestCase
     public function testGetToken()
     {
         static::$client = static::createClient();
-        static::$client->request('POST', '/login_check', ['_username' => 'lexik', '_password' => 'dummy']);
+        static::$client->jsonRequest('POST', '/login_check', ['username' => 'lexik', 'password' => 'dummy']);
 
         $response = static::$client->getResponse();
 
@@ -45,8 +45,8 @@ class GetTokenTest extends TestCase
             $payloadTested->payload = $e->getPayload();
         });
 
-        static::$client->request('POST', '/login_check', ['_username' => 'lexik', '_password' => 'dummy']);
-        static::$client->request('GET', '/api/secured', [], [], ['HTTP_AUTHORIZATION' => 'Bearer ' . $this->getToken(static::$client->getResponse())]);
+        static::$client->jsonRequest('POST', '/login_check', ['username' => 'lexik', 'password' => 'dummy']);
+        static::$client->jsonRequest('GET', '/api/secured', [], ['HTTP_AUTHORIZATION' => 'Bearer ' . $this->getToken(static::$client->getResponse())]);
 
         $this->assertArrayHasKey('added_data', $payloadTested->payload, 'The payload should contains a "added_data" claim.');
         $this->assertSame('still visible after the event', $payloadTested->payload['added_data'], 'The "added_data" claim should be equal to "still visible after the event".');
@@ -62,7 +62,7 @@ class GetTokenTest extends TestCase
             $e->setHeader($e->getHeader() + ['foo' => 'bar']);
         });
 
-        static::$client->request('POST', '/login_check', ['_username' => 'lexik', '_password' => 'dummy']);
+        static::$client->jsonRequest('POST', '/login_check', ['username' => 'lexik', 'password' => 'dummy']);
 
         $decoder = static::$kernel->getContainer()->get('lexik_jwt_authentication.encoder');
         $payload = $decoder->decode($token = $this->getToken(static::$client->getResponse()));
@@ -83,7 +83,7 @@ class GetTokenTest extends TestCase
     public function testGetTokenFromInvalidCredentials()
     {
         static::$client = static::createClient();
-        static::$client->request('POST', '/login_check', ['_username' => 'lexik', '_password' => 'wrong']);
+        static::$client->jsonRequest('POST', '/login_check', ['username' => 'lexik', 'password' => 'wrong']);
 
         $response = static::$client->getResponse();
 

--- a/Tests/Functional/TestCase.php
+++ b/Tests/Functional/TestCase.php
@@ -43,7 +43,7 @@ abstract class TestCase extends WebTestCase
     {
         $client = static::$client ?: static::createClient();
 
-        $client->request('POST', '/login_check', ['_username' => 'lexik', '_password' => 'dummy']);
+        $client->jsonRequest('POST', '/login_check', ['username' => 'lexik', 'password' => 'dummy']);
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 

--- a/Tests/Functional/Utils/CallableEventSubscriber.php
+++ b/Tests/Functional/Utils/CallableEventSubscriber.php
@@ -10,7 +10,6 @@ use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTExpiredEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTNotFoundEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class CallableEventSubscriber implements EventSubscriberInterface

--- a/Tests/Functional/app/config/security_in_memory.yml
+++ b/Tests/Functional/app/config/security_in_memory.yml
@@ -10,8 +10,8 @@ security:
             pattern:  ^/login
             stateless: true
             provider: in_memory
-            form_login:
-                check_path: /login_check
+            json_login:
+                check_path: login_check
                 require_previous_session: false
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure

--- a/Tests/Functional/app/config/security_lexik_jwt.yml
+++ b/Tests/Functional/app/config/security_lexik_jwt.yml
@@ -10,8 +10,8 @@ security:
             pattern:  ^/login
             stateless: true
             provider: in_memory
-            form_login:
-                check_path: /login_check
+            json_login:
+                check_path: login_check
                 require_previous_session: false
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure

--- a/Tests/Services/JWSProvider/LcobucciJWSProviderTest.php
+++ b/Tests/Services/JWSProvider/LcobucciJWSProviderTest.php
@@ -78,7 +78,8 @@ rT9kcwLvwUGRmm5HVAz06a9t6gOj0pvoR2oOn9GS7zWCxd3f8vL7nA==
             ->expects($this->once())
             ->method('loadKey')
             ->with('private')
-            ->willReturn(<<<EOF
+            ->willReturn(
+                <<<EOF
 -----BEGIN EC PRIVATE KEY-----
 MIHcAgEBBEIB+EYtmPtvg88MzxsRzgDGlKh+Z/iU99nmgKUjnw7+3eePeNQjaALU
 DH+P7PNnF9nwfmQGTUBgQwtznmLAQcVdB3GgBwYFK4EEACOhgYkDgYYABAFp/WFf
@@ -87,7 +88,7 @@ c+pDtNlumEvaA05RzwAGHve4mIi7RWaRQ2yAZfElRRV5f73h8eaG8qyNp6OtpuUO
 TkeeWHzDF5tKLvuO0HGEX9N7Fn0dOBWZYVSDk/iaZw==
 -----END EC PRIVATE KEY-----
 EOF
-        );
+            );
         $keyLoaderMock
             ->expects($this->once())
             ->method('getPassphrase')

--- a/TokenExtractor/ChainTokenExtractor.php
+++ b/TokenExtractor/ChainTokenExtractor.php
@@ -36,8 +36,7 @@ class ChainTokenExtractor implements \IteratorAggregate, TokenExtractorInterface
     /**
     * Removes a token extractor from the map.
     *
-     * @param \Closure $filter A function taking an extractor as argument,
-                      used to find the extractor to remove,
+    * @param \Closure $filter A function taking an extractor as argument, used to find the extractor to remove.
     *
     * @return bool True in case of success, false otherwise
     */

--- a/composer.json
+++ b/composer.json
@@ -52,9 +52,9 @@
         "symfony/translation-contracts": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "^4.4|^5.3|^6.0",
+        "symfony/browser-kit": "^5.4|^6.0",
         "symfony/console": "^4.4|^5.3|^6.0",
-        "symfony/dom-crawler": "^4.4|^5.3|^6.0",
+        "symfony/dom-crawler": "^5.4|^6.0",
         "symfony/filesystem": "^4.4|^5.3|^6.0",
         "symfony/framework-bundle": "^4.4|^5.3|^6.0",
         "symfony/phpunit-bridge": "^4.4|^5.3|^6.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,7 @@
     </filter>
 
     <php>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="9.5"></env>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=27"></env>
     </php>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -4,34 +4,42 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\PhpVersion;
-use Rector\Doctrine\Set\DoctrineSetList;
-use Rector\Php74\Rector\Property\TypedPropertyRector;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
+use Rector\PHPUnit\Rector\Class_\AddSeeTestAnnotationRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Rector\Symfony\Set\SymfonyLevelSetList;
 use Rector\Symfony\Set\SymfonySetList;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_71,
         SymfonyLevelSetList::UP_TO_SYMFONY_44,
-        SymfonySetList::SYMFONY_STRICT,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
     ]);
     $rectorConfig->phpVersion(PhpVersion::PHP_71);
-    $rectorConfig->importShortClasses();
+    $rectorConfig->importShortClasses(false);
+    $rectorConfig->importNames();
     $rectorConfig->bootstrapFiles([
         __DIR__ . '/vendor/autoload.php',
     ]);
+    $rectorConfig->parallel();
     $rectorConfig->paths([__DIR__]);
     $rectorConfig->skip([
+        // Path
         __DIR__ . '/.github',
+        __DIR__ . '/DependencyInjection/Configuration.php',
         __DIR__ . '/Tests/DependencyInjection/LexikJWTAuthenticationExtensionTest.php',
         __DIR__ . '/vendor',
-    ]);
 
-    $services = $rectorConfig->services();
-    $services->set(TypedPropertyRector::class);
+        // Rules
+        AddSeeTestAnnotationRector::class,
+        JsonThrowOnErrorRector::class,
+        ReturnNeverTypeRector::class => [
+            __DIR__ . '/Security/User/JWTUserProvider.php',
+        ],
+    ]);
 };


### PR DESCRIPTION
Fix https://github.com/lexik/LexikJWTAuthenticationBundle/issues/1114 and all CI.

PHP 7.1 and symfony 4.4 cannot be tested in the CI but are still supported. Mainly because of the tests that need the browser-kit 5.4 at least and interface compatibility (without/with typing)

@chalasr after merge this, I would like a rebase on 3.x so that I can rework my other PR : https://github.com/lexik/LexikJWTAuthenticationBundle/pull/1108