### PR TITLE
Remove deprecation symfony 6.3

### DIFF
--- a/Command/CheckConfigCommand.php
+++ b/Command/CheckConfigCommand.php
@@ -36,7 +36,7 @@ class CheckConfigCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(static::$defaultName)

--- a/Command/GenerateTokenCommand.php
+++ b/Command/GenerateTokenCommand.php
@@ -40,7 +40,7 @@ class GenerateTokenCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(static::$defaultName)

--- a/DependencyInjection/Compiler/ApiPlatformOpenApiPass.php
+++ b/DependencyInjection/Compiler/ApiPlatformOpenApiPass.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ApiPlatformOpenApiPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('lexik_jwt_authentication.api_platform.openapi.factory') || !$container->hasParameter('security.firewalls')) {
             return;

--- a/DependencyInjection/Compiler/DeprecateLegacyGuardAuthenticatorPass.php
+++ b/DependencyInjection/Compiler/DeprecateLegacyGuardAuthenticatorPass.php
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
  */
 class DeprecateLegacyGuardAuthenticatorPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasParameter('lexik_jwt_authentication.authenticator_manager_enabled') || !$container->getParameter('lexik_jwt_authentication.authenticator_manager_enabled')) {
             return;

--- a/DependencyInjection/Compiler/WireGenerateTokenCommandPass.php
+++ b/DependencyInjection/Compiler/WireGenerateTokenCommandPass.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class WireGenerateTokenCommandPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('lexik_jwt_authentication.generate_token_command') || !$container->hasDefinition('security.context_listener')) {
             return;

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -26,7 +26,7 @@ class LexikJWTAuthenticationExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/DependencyInjection/Security/Factory/JWTAuthenticatorFactoryTrait.php
+++ b/DependencyInjection/Security/Factory/JWTAuthenticatorFactoryTrait.php
@@ -48,7 +48,7 @@ trait JWTAuthenticatorFactoryTrait
     /**
      * {@inheritdoc}
      */
-    public function addConfiguration(NodeDefinition $node)
+    public function addConfiguration(NodeDefinition $node): void
     {
         $node
             ->children()

--- a/DependencyInjection/Security/Factory/JWTUserFactory.php
+++ b/DependencyInjection/Security/Factory/JWTUserFactory.php
@@ -18,18 +18,18 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 final class JWTUserFactory implements UserProviderFactoryInterface
 {
-    public function create(ContainerBuilder $container, $id, $config)
+    public function create(ContainerBuilder $container, $id, $config): void
     {
         $container->setDefinition($id, new ChildDefinition('lexik_jwt_authentication.security.jwt_user_provider'))
             ->replaceArgument(0, $config['class']);
     }
 
-    public function getKey()
+    public function getKey(): string
     {
         return 'lexik_jwt';
     }
 
-    public function addConfiguration(NodeDefinition $node)
+    public function addConfiguration(NodeDefinition $node): void
     {
         $node
             ->children()

--- a/LexikJWTAuthenticationBundle.php
+++ b/LexikJWTAuthenticationBundle.php
@@ -27,7 +27,7 @@ class LexikJWTAuthenticationBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 
@@ -58,13 +58,5 @@ class LexikJWTAuthenticationBundle extends Bundle
         if (method_exists($extension, 'addSecurityListenerFactory')) {
             $extension->addSecurityListenerFactory(new JWTFactory(false)); // BC 1.x, to be removed in 3.0
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function registerCommands(Application $application)
-    {
-        // noop
     }
 }

--- a/Tests/Functional/Bundle/DependencyInjection/BundleExtension.php
+++ b/Tests/Functional/Bundle/DependencyInjection/BundleExtension.php
@@ -12,7 +12,7 @@ class BundleExtension extends Extension implements PrependExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         // Annotation must be disabled since this bundle doesn't use Doctrine
         // The framework allows enabling/disabling them only since symfony 3.2 where
@@ -29,7 +29,7 @@ class BundleExtension extends Extension implements PrependExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
     }
 }

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -7,8 +7,8 @@ use Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle;
 use Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\Bundle\Bundle;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
-use Symfony\Bundle\SecurityBundle\SecurityBundle\Security;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
@@ -55,7 +55,7 @@ class AppKernel extends Kernel
         return $bundles;
     }
 
-    public function getRootDir()
+    public function getRootDir(): string
     {
         return __DIR__;
     }
@@ -79,7 +79,7 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config_router_utf8.yml');
 
@@ -159,7 +159,7 @@ class AppKernel extends Kernel
         return $this->encoder;
     }
 
-    protected function build(ContainerBuilder $container)
+    protected function build(ContainerBuilder $container): void
     {
         $container->register('logger', NullLogger::class);
 


### PR DESCRIPTION
This is to remove deprecation notices on the Symfony 6.3 CI and adding this type should not break the bundle because all of them are on internal elements