### PR TITLE
add description to authentication path

### DIFF
--- a/OpenApi/OpenApiFactory.php
+++ b/OpenApi/OpenApiFactory.php
@@ -70,6 +70,7 @@ class OpenApiFactory implements OpenApiFactoryInterface
                     ],
                 ])
                 ->withSummary('Creates a user token.')
+                ->withDescription('Creates a user token.')
                 ->withRequestBody(
                     (new RequestBody())
                     ->withDescription('The login data')

--- a/Tests/Functional/Command/ApiPlatformOpenApiExportCommandTest.php
+++ b/Tests/Functional/Command/ApiPlatformOpenApiExportCommandTest.php
@@ -103,6 +103,7 @@ class ApiPlatformOpenApiExportCommandTest extends TestCase
           }
         },
         "summary": "Creates a user token.",
+        "description": "Creates a user token.",
         "tags": [
           "Login Check"
         ]


### PR DESCRIPTION
Fix OpenAPI validation Operation "description" must be present and non-empty string.
Fixes #1148 