### PR TITLE
Replace the usage of the built-in PHP now() function with Clock

### DIFF
--- a/Services/JWSProvider/LcobucciJWSProvider.php
+++ b/Services/JWSProvider/LcobucciJWSProvider.php
@@ -103,7 +103,7 @@ class LcobucciJWSProvider implements JWSProviderInterface
             $jws = $jws->withHeader($k, $v);
         }
 
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
 
         $issuedAt = $payload['iat'] ?? $now;
         unset($payload['iat']);


### PR DESCRIPTION
This pull request addresses the enhancement and refactoring of the time-related operation. Currently, the codebase relies on the built-in PHP `now()` function for obtaining the current time. However, to improve testability, flexibility, and adherence to best practices, this change introduces the use of an injected clock interface.