### PR TITLE
feat: 3.x migrate to "lcobucci/jwt" v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
               with:
                   php-version: "${{ matrix.php }}"
                   tools: "composer:v2,flex"
+                  extensions: sodium
 
             - name: "Set Composer stability"
               if: "matrix.symfony == '6.3.*@dev'"

--- a/Tests/Functional/GetTokenTest.php
+++ b/Tests/Functional/GetTokenTest.php
@@ -3,7 +3,6 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional;
 
 use Lcobucci\JWT\Encoding\JoseEncoder;
-use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Token\Parser as JWTParser;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTAuthenticatedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
@@ -70,14 +69,11 @@ class GetTokenTest extends TestCase
         $this->assertArrayHasKey('custom', $payload, 'The payload should contains a "custom" claim.');
         $this->assertSame('dummy', $payload['custom'], 'The "custom" claim should be equal to "dummy".');
 
-        if (class_exists(JWTParser::class)) {
-            $parser = new JWTParser(new JoseEncoder());
-        } else {
-            $parser = new Parser();
-        }
+        $parser = new JWTParser(new JoseEncoder());
+
         $jws = $parser->parse($token);
 
-        $this->assertArrayHasKey('foo', method_exists($jws, 'headers') ? $jws->headers()->all() : $jws->getHeaders(), 'The payload should contains a custom "foo" header.');
+        $this->assertArrayHasKey('foo', $jws->headers()->all(), 'The payload should contains a custom "foo" header.');
     }
 
     public function testGetTokenFromInvalidCredentials()

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require": {
         "php": ">=8.1",
         "ext-openssl": "*",
-        "lcobucci/jwt": "^3.4|^4.0",
+        "lcobucci/jwt": "^5.0",
         "symfony/config": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/deprecation-contracts": "^2.4|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "^5.4|^6.0",
+        "symfony/clock": "^6.3",
         "symfony/console": "^5.4|^6.0",
         "symfony/dom-crawler": "^5.4|^6.0",
         "symfony/filesystem": "^5.4|^6.0",


### PR DESCRIPTION
feat: add support for psr/clock

To be honest i do not have much knowledge about this topic.

I just followed this mirgration guide https://lcobucci-jwt.readthedocs.io/en/latest/upgrading/
V5 does use [psr/clock](https://packagist.org/packages/psr/clock), instead of v4 with there own clock implementation.

As this is a new major version, i see no need to support versions <5

I added this PR for 3.x Branch as well. But could be a seperate PR if you want to.
https://github.com/lexik/LexikJWTAuthenticationBundle/pull/1155