### PR TITLE
Added: JWT security scheme to openapi

### DIFF
--- a/OpenApi/OpenApiFactory.php
+++ b/OpenApi/OpenApiFactory.php
@@ -44,6 +44,17 @@ class OpenApiFactory implements OpenApiFactoryInterface
         $openApi = ($this->decorated)($context);
 
         $openApi
+            ->getComponents()->getSecuritySchemes()->offsetSet(
+                'JWT',
+                new \ArrayObject([
+                        'type' => 'http',
+                        'scheme' => 'bearer',
+                        'bearerFormat' => 'JWT',
+                    ]
+                )
+            );
+
+        $openApi
             ->getPaths()
             ->addPath($this->checkPath, (new PathItem())->withPost(
                 (new Operation())

--- a/Tests/Functional/Command/ApiPlatformOpenApiExportCommandTest.php
+++ b/Tests/Functional/Command/ApiPlatformOpenApiExportCommandTest.php
@@ -118,7 +118,13 @@ class ApiPlatformOpenApiExportCommandTest extends TestCase
     "requestBodies": {},
     "responses": {},
     "schemas": {},
-    "securitySchemes": {}
+    "securitySchemes": {
+      "JWT": {
+        "bearerFormat": "JWT",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
   },
   "security": [],
   "tags": []


### PR DESCRIPTION
After that it's possible to add token in swagger ui without defining `Bearer` prefix.

PS: Currently there's a bug with `$checkPath`, `$usernamePath` & `$passwordPath`. If you're using route names instead of paths, in swagger ui/docs you get `POST auth` instead of `POST /auth`, so you cannot validate via swagger ui. I haven't found an elegant way to load `GeneratorInterface` service :/