### PR TITLE
feat: add support for partitioned cookies

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -110,6 +110,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('domain')->defaultNull()->end()
                             ->scalarNode('secure')->defaultTrue()->end()
                             ->scalarNode('httpOnly')->defaultTrue()->end()
+                            ->scalarNode('partitioned')->defaultFalse()->end()
                             ->arrayNode('split')
                                 ->scalarPrototype()->end()
                             ->end()

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * This is the class that loads and manages your bundle configuration.
@@ -115,6 +116,10 @@ class LexikJWTAuthenticationExtension extends Extension
 
             $cookieProviders = [];
             foreach ($config['set_cookies'] as $name => $attributes) {
+                if ($attributes['partitioned'] && Kernel::VERSION < '6.4') {
+                    throw new \LogicException(sprintf('The `partitioned` option for cookies is only available for Symfony 6.4 and above. You are currently on version %s', Kernel::VERSION));
+                }
+                
                 $container
                     ->setDefinition($id = "lexik_jwt_authentication.cookie_provider.$name", new ChildDefinition('lexik_jwt_authentication.cookie_provider'))
                     ->replaceArgument(0, $name)
@@ -124,7 +129,8 @@ class LexikJWTAuthenticationExtension extends Extension
                     ->replaceArgument(4, $attributes['domain'])
                     ->replaceArgument(5, $attributes['secure'])
                     ->replaceArgument(6, $attributes['httpOnly'])
-                    ->replaceArgument(7, $attributes['split']);
+                    ->replaceArgument(7, $attributes['split'])
+                    ->replaceArgument(8, $attributes['partitioned']);
                 $cookieProviders[] = new Reference($id);
             }
 

--- a/Resources/config/cookie.xml
+++ b/Resources/config/cookie.xml
@@ -14,6 +14,7 @@
             <argument/> <!-- Default secure -->
             <argument/> <!-- Default httpOnly -->
             <argument>null</argument> <!-- Default split -->
+            <argument>false</argument> <!-- Default partitioned -->
         </service>
     </services>
 </container>

--- a/Resources/doc/1-configuration-reference.rst
+++ b/Resources/doc/1-configuration-reference.rst
@@ -140,6 +140,7 @@ when the cookie token extractor is enabled
     #      domain: null (null means automatically set by symfony)
     #      secure: true (default to true)
     #      httpOnly: true
+    #      partitioned: false
 
 Automatically generating split cookies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -170,6 +171,7 @@ Keep in mind, that SameSite attribute is **not supported** in
             path: /
             domain: null
             httpOnly: false
+            partitioned: false # Only for Symfony 6.4 or higher
             split:
                 - header
                 - payload
@@ -180,6 +182,7 @@ Keep in mind, that SameSite attribute is **not supported** in
             path: /
             domain: null
             httpOnly: true
+            partitioned: false # Only for Symfony 6.4 or higher
             split:
                 - signature
 


### PR DESCRIPTION
This PR adds support for partitioned third-party cookies in a backwards compatible way, as described in #1166.

I have updated the documentation's configuration examples, but have not added any tests regarding this new option as the existing tests did not seem to cover similar options. I'll gladly add some if you think it's worth it.

Let me know if you have any comments/feedback!

---

closes #1166