### PR TITLE
 feat: Invalidate a JWT token

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -247,6 +247,16 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('blocklist_token')
+                    ->addDefaultsIfNotSet()
+                    ->canBeEnabled()
+                    ->children()
+                        ->scalarNode('cache')
+                            ->defaultValue('cache.app')
+                            ->info('Storage to track blocked tokens')
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ->end();
 

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -169,6 +169,12 @@ class LexikJWTAuthenticationExtension extends Extension
         }
 
         $this->processWithWebTokenConfig($config, $container, $loader);
+
+        if ($this->isConfigEnabled($container, $config['blocklist_token'])) {
+            $loader->load('blocklist_token.xml');
+            $blockListTokenConfig = $config['blocklist_token'];
+            $container->setAlias('lexik_jwt_authentication.blocklist_token.cache', $blockListTokenConfig['cache']);
+        }
     }
 
     private function createTokenExtractors(ContainerBuilder $container, array $tokenExtractorsConfig): array

--- a/EventListener/AddClaimsToJWTListener.php
+++ b/EventListener/AddClaimsToJWTListener.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\EventListener;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
+
+class AddClaimsToJWTListener
+{
+    public function __invoke(JWTCreatedEvent $event): void
+    {
+        $data = $event->getData();
+
+        if (!isset($data['jti'])) {
+            $data['jti'] = bin2hex(random_bytes(16));
+
+            $event->setData($data);
+        }
+    }
+}

--- a/EventListener/BlockJWTListener.php
+++ b/EventListener/BlockJWTListener.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\EventListener;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\MissingClaimException;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\BlockedTokenManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\CacheItemPoolBlockedTokenManager;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\DisabledException;
+use Symfony\Component\Security\Http\Event\LoginFailureEvent;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+
+class BlockJWTListener
+{
+    private $blockedTokenManager;
+    private $tokenExtractor;
+    private $jwtManager;
+
+    public function __construct(
+        BlockedTokenManagerInterface $blockedTokenManager,
+        TokenExtractorInterface      $tokenExtractor,
+        JWTTokenManagerInterface     $jwtManager
+    ) {
+        $this->blockedTokenManager = $blockedTokenManager;
+        $this->tokenExtractor = $tokenExtractor;
+        $this->jwtManager = $jwtManager;
+    }
+
+    public function onLoginFailure(LoginFailureEvent $event): void
+    {
+        $exception = $event->getException();
+        if (($exception instanceof DisabledException) || ($exception->getPrevious() instanceof DisabledException)) {
+            $this->blockTokenFromRequest($event->getRequest());
+        }
+    }
+
+    public function onLogout(LogoutEvent $event): void
+    {
+        $this->blockTokenFromRequest($event->getRequest());
+    }
+
+    private function blockTokenFromRequest(Request $request): void
+    {
+        $token = $this->tokenExtractor->extract($request);
+
+        if ($token === false) {
+            // There's nothing to block if the token isn't in the request
+            return;
+        }
+
+        try {
+            $payload = $this->jwtManager->parse($token);
+        } catch (JWTDecodeFailureException $e) {
+            // Ignore decode failures, this would mean the token is invalid anyway
+            return;
+        }
+
+        try {
+            $this->blockedTokenManager->add($payload);
+        } catch (MissingClaimException $e) {
+            // We can't block a token missing the claims our system requires, so silently ignore this one
+        }
+    }
+}

--- a/EventListener/RejectBlockedTokenListener.php
+++ b/EventListener/RejectBlockedTokenListener.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\EventListener;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTAuthenticatedEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\InvalidTokenException;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\MissingClaimException;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\BlockedTokenManagerInterface;
+
+class RejectBlockedTokenListener
+{
+    private $blockedTokenManager;
+
+    public function __construct(BlockedTokenManagerInterface $blockedTokenManager)
+    {
+        $this->blockedTokenManager = $blockedTokenManager;
+    }
+
+    /**
+     * @throws InvalidTokenException if the JWT is blocked
+     */
+    public function __invoke(JWTAuthenticatedEvent $event): void
+    {
+        try {
+            if ($this->blockedTokenManager->has($event->getPayload())) {
+                throw new InvalidTokenException('JWT blocked');
+            }
+        } catch (MissingClaimException $e) {
+            // Do nothing if the required claims do not exist on the payload (older JWTs won't have the "jti" claim the manager requires)
+        }
+    }
+}

--- a/Exception/MissingClaimException.php
+++ b/Exception/MissingClaimException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Exception;
+
+use Throwable;
+
+class MissingClaimException extends JWTFailureException
+{
+    public function __construct(
+        string $claim,
+        Throwable $previous = null
+    ) {
+        parent::__construct('missing_claim', sprintf('Missing required "%s" claim on JWT payload.', $claim), $previous);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The bulk of the documentation is stored in the [`Resources/doc`](Resources/doc/i
   * [Creating JWT tokens programmatically](Resources/doc/7-manual-token-creation.rst)
   * [A database-less user provider](Resources/doc/8-jwt-user-provider.rst)
   * [Accessing the authenticated JWT token](Resources/doc/9-access-authenticated-jwt-token.rst)
+  * [Invalidate token on logout](Resources/doc/10-invalidate-token-on-logout.rst)
 
 Community Support
 -----------------

--- a/Resources/config/blocklist_token.xml
+++ b/Resources/config/blocklist_token.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="lexik_jwt_authentication.event_listener.add_claims_to_jwt_listener" class="Lexik\Bundle\JWTAuthenticationBundle\EventListener\AddClaimsToJWTListener">
+            <tag name="kernel.event_listener" event="lexik_jwt_authentication.on_jwt_created" />
+        </service>
+
+        <service id="lexik_jwt_authentication.event_listener.block_jwt_listener" class="Lexik\Bundle\JWTAuthenticationBundle\EventListener\BlockJWTListener">
+            <argument type="service" id="lexik_jwt_authentication.blocked_token_manager"/>
+            <argument type="service" id="lexik_jwt_authentication.extractor.chain_extractor"/>
+            <argument type="service" id="lexik_jwt_authentication.jwt_manager"/>
+            <tag name="kernel.event_listener" event="Symfony\Component\Security\Http\Event\LoginFailureEvent" method="onLoginFailure" dispatcher="event_dispatcher"/>
+            <tag name="kernel.event_listener" event="Symfony\Component\Security\Http\Event\LogoutEvent" method="onLogout" dispatcher="event_dispatcher"/>
+        </service>
+
+        <service id="lexik_jwt_authentication.event_listener.reject_blocked_token_listener" class="Lexik\Bundle\JWTAuthenticationBundle\EventListener\RejectBlockedTokenListener">
+            <argument type="service" id="lexik_jwt_authentication.blocked_token_manager"/>
+            <tag name="kernel.event_listener" event="lexik_jwt_authentication.on_jwt_authenticated"/>
+        </service>
+
+        <service id="lexik_jwt_authentication.blocked_token_manager" class="Lexik\Bundle\JWTAuthenticationBundle\Services\BlockedToken\CacheItemPoolBlockedTokenManager">
+            <argument type="service" id="lexik_jwt_authentication.blocklist_token.cache"/>
+        </service>
+
+        <service id="Lexik\Bundle\JWTAuthenticationBundle\Services\BlockedTokenManagerInterface" alias="lexik_jwt_authentication.blocked_token_manager" />
+
+    </services>
+
+</container>

--- a/Resources/doc/1-configuration-reference.rst
+++ b/Resources/doc/1-configuration-reference.rst
@@ -86,6 +86,11 @@ Full default configuration
         # remove the token from the response body when using cookies
         remove_token_from_body_when_cookies_used: true
 
+        # invalidate the token on logout by storing it in the cache
+        blocklist_token:
+            enabled: true
+            cache: cache.app
+
 Encoder configuration
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/Resources/doc/10-invalidate-token.rst
+++ b/Resources/doc/10-invalidate-token.rst
@@ -1,0 +1,89 @@
+Invalidate token
+================
+
+The token blocklist relies on the ``jti`` claim, a standard claim designed for tracking and revoking JWTs. `"jti" (JWT ID) Claim <https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7>`_
+
+The blocklist storage utilizes a cache implementing ``Psr\Cache\CacheItemPoolInterface``. The cache stores the ``jti`` of the blocked token to the cache, and the cache item expires after the "exp" (expiration time) claim of the token
+
+Configuration
+~~~~~~~~~~~~~
+
+To configure token blocklist, update your `lexik_jwt_authentication.yaml` file:
+
+.. code-block:: yaml
+
+    # config/packages/lexik_jwt_authentication.yaml
+    # ...
+    lexik_jwt_authentication:
+    # ...
+        # invalidate the token on logout by storing it in the cache
+        blocklist_token:
+            enabled: true
+            cache: cache.app
+
+
+Enabling ``blocklist_token`` causes the activation of listeners:
+
+* an event listener ``Lexik\Bundle\JWTAuthenticationBundle\EventListenerAddClaimsToJWTListener`` which adds a ``jti`` claim if not present when the token is created
+
+* an event listener ``Lexik\Bundle\JWTAuthenticationBundle\BlockJWTListener`` which blocks JWTs on logout (``Symfony\Component\Security\Http\Event\LogoutEvent``)
+or on login failure due to the user not being enabled (``Symfony\Component\Security\Core\Exception\DisabledException``)
+
+* an event listener ``Lexik\Bundle\JWTAuthenticationBundle\RejectBlockedTokenListener`` which rejects blocked tokens during authentication
+
+To block JWTs on logout, you must either activate logout in the firewall configuration or do it programmatically
+
+* by firewall configuration
+
+    .. code-block:: yaml
+        # config/packages/security.yaml
+        security:
+            enable_authenticator_manager: true
+            firewalls:
+                api:
+                    ...
+                    jwt: ~
+                    logout:
+                        path: app_logout
+
+* programmatically in a controller action
+
+    .. code-block:: php
+        use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+        use Symfony\Component\HttpFoundation\JsonResponse;
+        use Symfony\Component\HttpFoundation\Request;
+        use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+        use Symfony\Component\Security\Http\Event\LogoutEvent;
+        //...
+        class SecurityController
+        {
+            //...
+            public function logout(Request $request, EventDispatcherInterface $eventDispatcher, TokenStorageInterface $tokenStorage)
+            {
+                $eventDispatcher->dispatch(new LogoutEvent($request, $tokenStorage->getToken()));
+
+                return new JsonResponse();
+            }
+        ]
+
+Refer to `Symfony logging out <https://symfony.com/doc/current/security.html#logging-out>`_  for more details.
+
+Changing blocklist storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To change the blocklist storage, refer to `Configuring Cache with FrameworkBundle <https://symfony.com/doc/current/cache.html#configuring-cache-with-frameworkbundle>`_
+
+.. code-block:: yaml
+
+    # config/packages/framework.yaml
+    framework:
+        # ...
+        cache:
+            default_redis_provider: 'redis://localhost'
+            pools:
+                block_list_token_cache_pool:
+                    adapter: cache.adapter.redis
+        # ...
+        blocklist_token:
+            enabled: true
+            cache: block_list_token_cache_pool

--- a/Services/BlockedToken/CacheItemPoolBlockedTokenManager.php
+++ b/Services/BlockedToken/CacheItemPoolBlockedTokenManager.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Services\BlockedToken;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\MissingClaimException;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\BlockedTokenManagerInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+class CacheItemPoolBlockedTokenManager implements BlockedTokenManagerInterface
+{
+    private $cacheJwt;
+
+    public function __construct(CacheItemPoolInterface $cacheJwt)
+    {
+        $this->cacheJwt = $cacheJwt;
+    }
+
+    public function add(array $payload): bool
+    {
+        if (!isset($payload['exp'])) {
+            throw new MissingClaimException('exp');
+        }
+
+        $expiration = new DateTimeImmutable('@' . $payload['exp'], new DateTimeZone('UTC'));
+        $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        // If the token is already expired, there's no point in adding it to storage
+        if ($expiration <= $now) {
+            return false;
+        }
+
+        $cacheExpiration = $expiration->add(new DateInterval('PT5M'));
+
+        if (!isset($payload['jti'])) {
+            throw new MissingClaimException('jti');
+        }
+
+        $cacheItem = $this->cacheJwt->getItem($payload['jti']);
+        $cacheItem->set([]);
+        $cacheItem->expiresAt($cacheExpiration);
+        $this->cacheJwt->save($cacheItem);
+
+        return true;
+    }
+
+    public function has(array $payload): bool
+    {
+        if (!isset($payload['jti'])) {
+            throw new MissingClaimException('jti');
+        }
+
+        return $this->cacheJwt->hasItem($payload['jti']);
+    }
+
+    public function remove(array $payload): void
+    {
+        if (!isset($payload['jti'])) {
+            throw new MissingClaimException('jti');
+        }
+
+        $this->cacheJwt->deleteItem($payload['jti']);
+    }
+}

--- a/Services/BlockedTokenManagerInterface.php
+++ b/Services/BlockedTokenManagerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Services;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\MissingClaimException;
+
+interface BlockedTokenManagerInterface
+{
+    /**
+     * @throws MissingClaimException if required claims do not exist in the payload
+     */
+    public function add(array $payload): bool;
+
+    /**
+     * @throws MissingClaimException if required claims do not exist in the payload
+     */
+    public function has(array $payload): bool;
+
+    /**
+     * @throws MissingClaimException if required claims do not exist in the payload
+     */
+    public function remove(array $payload): void;
+}

--- a/Tests/Functional/BlocklistTokenTest.php
+++ b/Tests/Functional/BlocklistTokenTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Services\CacheItemPoolBlockedTokenManager;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
+use Lexik\Bundle\JWTAuthenticationBundle\Tests\Stubs\UserProvider;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class BlocklistTokenTest extends TestCase
+{
+    public function testShouldInvalidateTokenOnLogoutWhenBlockListTokenIsEnabled()
+    {
+        static::$client = static::createClient(['test_case' => 'BlockListToken']);
+
+        $token = static::getAuthenticatedToken();
+
+        static::$client->jsonRequest('GET', '/api/secured', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::assertResponseIsSuccessful('Precondition - a valid token should be able to contact the api');
+
+        static::$client->jsonRequest('GET', '/api/logout', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::assertResponseStatusCodeSame(Response::HTTP_FOUND);
+
+        static::$client->jsonRequest('GET', '/api/secured', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED, 'Logout should invalidate token');
+
+        $responseBody = json_decode(static::$client->getResponse()->getContent(), true);
+        $this->assertEquals('Invalid JWT Token', $responseBody['message']);
+        $this->assertThatTokenIsInTheBlockList($token);
+    }
+
+    public function testShouldAddJtiWhenBlockListTokenIsEnabled()
+    {
+        static::$client = static::createClient(['test_case' => 'BlockListToken']);
+
+        $token = static::getAuthenticatedToken();
+        /** @var JWTManager $jwtManager */
+        $jwtManager = static::getContainer()->get('lexik_jwt_authentication.jwt_manager');
+        $payload = $jwtManager->parse($token);
+        self::assertNotEmpty($payload['jti']);
+    }
+
+    public function testShouldInvalidateTokenOnLogoutWhenBlockListTokenIsEnabledAndWhenUsingCustomLogout()
+    {
+        static::$client = static::createClient(['test_case' => 'BlockListToken']);
+
+        $token = static::getAuthenticatedToken();
+
+        static::$client->jsonRequest('GET', '/api/secured', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::assertResponseIsSuccessful('Precondition - a valid token should be able to contact the api');
+
+        static::$client->jsonRequest('GET', '/api/logout_custom', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        static::$client->jsonRequest('GET', '/api/secured', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED, 'Logout should invalidate token');
+
+        $responseBody = json_decode(static::$client->getResponse()->getContent(), true);
+        $this->assertEquals('Invalid JWT Token', $responseBody['message']);
+        $this->assertThatTokenIsInTheBlockList($token);
+    }
+
+    public function testShouldNotInvalidateTokenOnLogoutWhenBlockListTokenIsDisabled()
+    {
+        static::$client = static::createClient(['test_case' => 'BlockListTokenDisabled']);
+        $token = static::getAuthenticatedToken();
+
+        static::$client->jsonRequest('GET', '/api/secured', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::assertResponseIsSuccessful('Precondition - a valid token should be able to contact the api');
+
+        static::$client->jsonRequest('GET', '/api/logout', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::assertResponseStatusCodeSame(Response::HTTP_FOUND);
+
+        static::$client->jsonRequest('GET', '/api/secured', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::assertResponseStatusCodeSame(Response::HTTP_OK, 'Logout should NOT invalidate token when block list config is not enabled');
+    }
+
+    public function testShouldNotAddJtiWhenBlockListTokenIsDisabled()
+    {
+        static::$client = static::createClient(['test_case' => 'BlockListTokenDisabled']);
+
+        $token = static::getAuthenticatedToken();
+        /** @var JWTManager $jwtManager */
+        $jwtManager = static::getContainer()->get('lexik_jwt_authentication.jwt_manager');
+        $payload = $jwtManager->parse($token);
+        self::assertArrayNotHasKey('jti', $payload);
+    }
+
+    public function testShouldInvalidateTokenIfDisabledUserWhenBlockListTokenIsEnabled()
+    {
+        static::$client = static::createClient(['test_case' => 'BlockListToken']);
+        if ('lexik_jwt' === static::$kernel->getUserProvider()) {
+            $this->markTestSkipped('Test not implemented with lexik_jwt provider');
+        }
+
+        UserProvider::$users['lexik_disabled']['enabled'] = true;
+        $token = static::getAuthenticatedToken('lexik_disabled');
+
+        UserProvider::$users['lexik_disabled']['enabled'] = true;
+        static::$client->jsonRequest('GET', '/api/secured', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::assertResponseIsSuccessful('Should be able to contact the api');
+
+        /** @var UserProvider $userProvider */
+        UserProvider::$users['lexik_disabled']['enabled'] = false;
+        static::$client->jsonRequest('GET', '/api/secured', [], ['HTTP_AUTHORIZATION' => "Bearer $token"]);
+        static::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED, 'An user disabled should not be able to contact the api');
+        $this->assertThatTokenIsInTheBlockList($token);
+    }
+
+    private function assertThatTokenIsInTheBlockList(string $token): void
+    {
+        /** @var JWTManager $jwtManager */
+        $jwtManager = static::getContainer()->get('lexik_jwt_authentication.jwt_manager');
+        $payload = $jwtManager->parse($token);
+
+        /** @var CacheItemPoolInterface $cache */
+        $cache = static::getContainer()->get('lexik_jwt_authentication.blocklist_token.cache');
+        self::assertTrue($cache->hasItem($payload['jti']), 'The token should be in the block list');
+    }
+}

--- a/Tests/Functional/Bundle/Controller/TestController.php
+++ b/Tests/Functional/Bundle/Controller/TestController.php
@@ -2,8 +2,13 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\Bundle\Controller;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
 
 class TestController
 {
@@ -14,5 +19,17 @@ class TestController
             'roles' => $user->getRoles(),
             'username' => method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername(),
         ]);
+    }
+
+    public function logoutAction()
+    {
+        throw new \Exception('This should never be reached!');
+    }
+
+    public function logoutCustomAction(Request $request, EventDispatcherInterface $eventDispatcher, TokenStorageInterface $tokenStorage)
+    {
+        $eventDispatcher->dispatch(new LogoutEvent($request, $tokenStorage->getToken()));
+
+        return new Response();
     }
 }

--- a/Tests/Functional/TestCase.php
+++ b/Tests/Functional/TestCase.php
@@ -39,11 +39,11 @@ abstract class TestCase extends WebTestCase
         return $client;
     }
 
-    protected static function getAuthenticatedToken()
+    protected static function getAuthenticatedToken(string $username = 'lexik')
     {
         $client = static::$client ?: static::createClient();
 
-        $client->jsonRequest('POST', '/login_check', ['username' => 'lexik', 'password' => 'dummy']);
+        $client->jsonRequest('POST', '/login_check', ['username' => $username, 'password' => 'dummy']);
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 

--- a/Tests/Functional/app/config/BlockListToken/config.yml
+++ b/Tests/Functional/app/config/BlockListToken/config.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: '../base_config.yml' }
+
+lexik_jwt_authentication:
+    blocklist_token:
+        enabled: true

--- a/Tests/Functional/app/config/base_config.yml
+++ b/Tests/Functional/app/config/base_config.yml
@@ -19,3 +19,7 @@ services:
     Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\Bundle\Controller\TestController:
         arguments: ['@security.token_storage']
         public: true
+        tags: ['controller.service_arguments']
+
+    Lexik\Bundle\JWTAuthenticationBundle\Tests\Stubs\UserProvider:
+        public: true

--- a/Tests/Functional/app/config/base_security.yml
+++ b/Tests/Functional/app/config/base_security.yml
@@ -1,11 +1,16 @@
 security:
     providers:
         in_memory:
+            chain:
+                providers: [ 'lexik_in_memory', 'disabled_user_provider' ]
+        lexik_in_memory:
             memory:
                 users:
                     lexik:
                         password: dummy
                         roles: ROLE_USER
+        disabled_user_provider:
+            id: Lexik\Bundle\JWTAuthenticationBundle\Tests\Stubs\UserProvider
         jwt:
             lexik_jwt:
                 class: Lexik\Bundle\JWTAuthenticationBundle\Tests\Stubs\JWTUser

--- a/Tests/Functional/app/config/routing.yml
+++ b/Tests/Functional/app/config/routing.yml
@@ -6,3 +6,13 @@ secured:
     path:     /api/secured
     defaults:  { _controller: Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\Bundle\Controller\TestController::securedAction }
     methods:  [GET]
+
+app_logout:
+    path: /api/logout
+    defaults:  { _controller: Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\Bundle\Controller\TestController::logoutAction }
+    methods: GET
+
+app_logout_custom:
+    path: /api/logout_custom
+    defaults:  { _controller: Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\Bundle\Controller\TestController::logoutCustomAction }
+    methods: GET

--- a/Tests/Functional/app/config/security_in_memory.yml
+++ b/Tests/Functional/app/config/security_in_memory.yml
@@ -21,6 +21,8 @@ security:
             lazy: true
             provider: in_memory
             jwt: ~
+            logout:
+                path: app_logout
 
     access_control:
       - { path: ^/login, roles: PUBLIC_ACCESS }

--- a/Tests/Functional/app/config/security_lexik_jwt.yml
+++ b/Tests/Functional/app/config/security_lexik_jwt.yml
@@ -20,6 +20,8 @@ security:
             stateless: true
             provider: jwt
             jwt: ~
+            logout:
+                path: app_logout
 
     access_control:
       - { path: ^/login, roles: PUBLIC_ACCESS }

--- a/Tests/Services/BlockedToken/CacheItemPoolBlockedTokenManagerTest.php
+++ b/Tests/Services/BlockedToken/CacheItemPoolBlockedTokenManagerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Services\BlockedToken;
+
+use DateTime;
+use DateTimeImmutable;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\MissingClaimException;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\BlockedToken\CacheItemPoolBlockedTokenManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class CacheItemPoolBlockedTokenManagerTest extends TestCase
+{
+    private const JTI = '3de41d11099ed70e23e634eb32c959da';
+    private const IAT = 1699455323;
+
+    public function testAddPayloadWithoutExpirationShouldThrowsAnException()
+    {
+        $this->expectException(MissingClaimException::class);
+        $cacheAdapter = new ArrayAdapter();
+        $blockedTokenManager = new CacheItemPoolBlockedTokenManager($cacheAdapter);
+        $blockedTokenManager->add(
+            [
+                'iat' => self::IAT,
+                'jti' => self::JTI,
+                'roles' => [
+                    'ROLE_USER'
+                ],
+                'username' => 'lexik'
+            ]
+        );
+    }
+
+    public function testAddPayloadWithoutJitShouldThrowsAnException()
+    {
+        $this->expectException(MissingClaimException::class);
+        $cacheAdapter = new ArrayAdapter();
+        $blockedTokenManager = new CacheItemPoolBlockedTokenManager($cacheAdapter);
+        $blockedTokenManager->add(
+            [
+                'iat' => self::IAT,
+                "exp" => (int) (new DateTime('2050-01-01'))->format('U'),
+                'roles' => [
+                    'ROLE_USER'
+                ],
+                'username' => 'lexik'
+            ]
+        );
+    }
+
+    public function testShouldNotAddPayloadIfItHasExpired()
+    {
+        $cacheAdapter = new ArrayAdapter();
+        $blockedTokenManager = new CacheItemPoolBlockedTokenManager($cacheAdapter);
+        self::assertFalse(
+            $blockedTokenManager->add(
+                [
+                    'iat' => self::IAT,
+                    'jti' => self::JTI,
+                    "exp" => (int) (new DateTime('2020-01-01'))->format('U'),
+                    'roles' => [
+                        'ROLE_USER'
+                    ],
+                    'username' => 'lexik'
+                ]
+            )
+        );
+        self::assertCount(0, $cacheAdapter->getItems());
+    }
+
+    public function testShouldBlockTokenIfPaylaodHasNotExpired()
+    {
+        ClockMock::register(ArrayAdapter::class);
+
+        $cacheAdapter = new ArrayAdapter();
+        $blockedTokenManager = new CacheItemPoolBlockedTokenManager($cacheAdapter);
+
+        $expirationDateTime = new DateTimeImmutable('2050-01-01 00:00:00');
+        self::assertTrue(
+            $blockedTokenManager->add(
+                [
+                    'iat' => self::IAT,
+                    'jti' => self::JTI,
+                    "exp" => (int) $expirationDateTime->format('U'),
+                    'roles' => [
+                        'ROLE_USER'
+                    ],
+                    'username' => 'lexik'
+                ]
+            )
+        );
+        self::assertCount(1, $cacheAdapter->getValues());
+
+        self::assertTrue($cacheAdapter->hasItem(self::JTI));
+        self::assertNotNull($cacheAdapter->getItem(self::JTI));
+
+        ClockMock::withClockMock(($expirationDateTime->modify('+5 minutes 1 second')->format('U')));
+        self::assertFalse($cacheAdapter->hasItem(self::JTI), 'The cache item should have expired');
+        ClockMock::withClockMock(false);
+    }
+
+    public function testHasToken()
+    {
+        $cacheAdapter = new ArrayAdapter();
+        $blockedTokenManager = new CacheItemPoolBlockedTokenManager($cacheAdapter);
+
+        $expirationDateTime = new DateTimeImmutable('2050-01-01 00:00:00');
+        $payload = [
+            'iat' => self::IAT,
+            'jti' => self::JTI,
+            "exp" => (int) $expirationDateTime->format('U'),
+            'roles' => [
+                'ROLE_USER'
+            ],
+            'username' => 'lexik'
+        ];
+
+        self::assertFalse($blockedTokenManager->has($payload));
+
+        $blockedTokenManager->add(
+            [
+                'iat' => self::IAT,
+                'jti' => self::JTI,
+                "exp" => (int) $expirationDateTime->format('U'),
+                'roles' => [
+                    'ROLE_USER'
+                ],
+                'username' => 'lexik'
+            ]
+        );
+        self::assertTrue($blockedTokenManager->has($payload));
+
+        $blockedTokenManager->remove($payload);
+        self::assertFalse($blockedTokenManager->has($payload));
+    }
+}

--- a/Tests/Stubs/UserProvider.php
+++ b/Tests/Stubs/UserProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Stubs;
+
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Provides a disabled user that is not possible to create via yaml configuration
+ */
+final class UserProvider implements UserProviderInterface, ResetInterface
+{
+    private const DEFAULT_USERS = [
+        'lexik_disabled' => [
+            'username' => 'lexik_disabled',
+            'password' => 'dummy',
+            'roles' => ['ROLE_USER'],
+            'enabled' => true,
+        ]
+    ];
+
+    /**
+     * Are users enbled ?
+     */
+    public static $enabled = false;
+    public static $users = self::DEFAULT_USERS;
+
+    public function refreshUser(UserInterface $user): UserInterface
+    {
+        return $this->getUser($user->getUserIdentifier());
+    }
+
+    public function supportsClass(string $class): bool
+    {
+        return InMemoryUser::class === $class;
+    }
+
+    public function loadUserByUsername(string $username): UserInterface
+    {
+        return $this->getUser($username);
+    }
+
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        return $this->getUser($identifier);
+    }
+
+    private function getUser(string $username): InMemoryUser
+    {
+        $user = self::$users[strtolower($username)] ?? null;
+        if (null === $user) {
+            $ex = new UserNotFoundException(sprintf('Username "%s" does not exist.', $username));
+            $ex->setUserIdentifier($username);
+
+            throw $ex;
+        }
+
+        return new InMemoryUser($user['username'], $user['password'], $user['roles'], $user['enabled']);
+    }
+
+    public function reset(): void
+    {
+        self::$users = self::DEFAULT_USERS;
+    }
+}


### PR DESCRIPTION
This PR adds support for invalidating a JWT token #1137.

The code comes mainly from the discussion https://github.com/lexik/LexikJWTAuthenticationBundle/discussions/1005#discussioncomment-2612224  Thanks to @mbabker

I think that the PR meets the needs mentioned in https://github.com/lexik/LexikJWTAuthenticationBundle/issues/1137#issuecomment-1662762926

> 
> * This feature must be opt-in
> * Tokens should be given a jti claim whose value should be the only thing persisted: if the feature is enabled and a token's jti exists in the blocklist then that token must be rejected.
> * Feature detection should not be only based on the presence of the jti, as it mght break existing code that relies on this claim today.
> * The blacklist term should be avoided, alternative such as blocklist should be preferred :)
> * We will probably need a simple abstraction for the blocklist storage. A very limited set of built-in implementations should be provided, not necessarily as part of the first iteration (i.e. it can wait til another PR).
> 