### PR TITLE
Removed constructor property promotion to fix compatibility with PHP 7.x

### DIFF
--- a/Command/EnableEncryptionConfigCommand.php
+++ b/Command/EnableEncryptionConfigCommand.php
@@ -41,10 +41,14 @@ final class EnableEncryptionConfigCommand extends AbstractConfigCommand
      */
     protected static $defaultName = 'lexik:jwt:enable-encryption';
 
+    private ?AlgorithmManagerFactory $algorithmManagerFactory;
+
     public function __construct(
-        private ?AlgorithmManagerFactory $algorithmManagerFactory,
+        ?AlgorithmManagerFactory $algorithmManagerFactory = null
     ) {
         parent::__construct();
+
+        $this->algorithmManagerFactory = $algorithmManagerFactory;
     }
 
     /**


### PR DESCRIPTION
Looks like #1041 introduced PHP 7.x incompatible change. The issue is constructor property promotion in `\Lexik\Bundle\JWTAuthenticationBundle\Command\EnableEncryptionConfigCommand` class.