### PR TITLE
Fix for PHP <7.4 compatibility

### DIFF
--- a/Command/EnableEncryptionConfigCommand.php
+++ b/Command/EnableEncryptionConfigCommand.php
@@ -41,7 +41,10 @@ final class EnableEncryptionConfigCommand extends AbstractConfigCommand
      */
     protected static $defaultName = 'lexik:jwt:enable-encryption';
 
-    private ?AlgorithmManagerFactory $algorithmManagerFactory;
+    /**
+     * @var ?AlgorithmManagerFactory
+     */
+    private $algorithmManagerFactory;
 
     public function __construct(
         ?AlgorithmManagerFactory $algorithmManagerFactory = null


### PR DESCRIPTION
Typed properties are only allowed since PHP 7.4.
Fixes #1173 for PHP <7.4
Follow up for #1172