### PR TITLE
ci: Group GitHub Actions upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
With a monthly interval you might end up with quite a few PRs to upgrade GitHub Actions. Personally I find I have very rare cases where a GitHub Action upgrade breaks something and require me to upgrade one specific action. So most of the time grouping them will significantly reduce the noise.

This is highly subjective though so if you prefer how it currently is feel free to close this PR.