### PR TITLE
Allow setting advanced cookie name by dedicated configuration attribute

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -98,6 +98,7 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->children()
+                            ->scalarNode('name')->defaultNull()->end()
                             ->scalarNode('lifetime')
                                 ->defaultNull()
                                 ->info('The cookie lifetime. If null, the "token_ttl" option value will be used')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -98,7 +98,7 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->children()
-                            ->scalarNode('name')->defaultNull()->end()
+                            ->scalarNode('customName')->defaultNull()->end()
                             ->scalarNode('lifetime')
                                 ->defaultNull()
                                 ->info('The cookie lifetime. If null, the "token_ttl" option value will be used')

--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -120,10 +120,10 @@ class LexikJWTAuthenticationExtension extends Extension
                 if ($attributes['partitioned'] && Kernel::VERSION < '6.4') {
                     throw new \LogicException(sprintf('The `partitioned` option for cookies is only available for Symfony 6.4 and above. You are currently on version %s', Kernel::VERSION));
                 }
-                
+
                 $container
                     ->setDefinition($id = "lexik_jwt_authentication.cookie_provider.$name", new ChildDefinition('lexik_jwt_authentication.cookie_provider'))
-                    ->replaceArgument(0, $name)
+                    ->replaceArgument(0, $attributes['name'] ?? $name)
                     ->replaceArgument(1, $attributes['lifetime'] ?? ($config['token_ttl'] ?: 0))
                     ->replaceArgument(2, $attributes['samesite'])
                     ->replaceArgument(3, $attributes['path'])


### PR DESCRIPTION
Allow configurations like:

```
lexik_jwt_authentication:
    ...
    token_extractors:
        split_cookie:
            enabled: true
            cookies:
                - jwt_hp
                - jwt_s
    set_cookies:
        jwt_hp:
            customName: '%env(JWT_COOKIE_PREFIX)%jwt_hp'
            ...
        jwt_s:
            customName: '%env(JWT_COOKIE_PREFIX)%jwt_s'
            ...
```

With Gesdinet, it's already possible with:

```
gesdinet_jwt_refresh_token:
    token_parameter_name: '%env(JWT_COOKIE_PREFIX)%refresh_token'
    ...
```