### PR TITLE
Wrong type exception for AccessTokenLoader with certain configuration

### DIFF
--- a/Resources/config/web_token_verification.xml
+++ b/Resources/config/web_token_verification.xml
@@ -9,15 +9,15 @@
             <argument type="service" id="Jose\Bundle\JoseFramework\Services\JWSLoaderFactory" />
             <argument type="service" id="Jose\Bundle\JoseFramework\Services\JWELoaderFactory" on-invalid="null" />
             <argument type="service" id="Jose\Bundle\JoseFramework\Services\ClaimCheckerManagerFactory" />
-            <argument /> <!-- Claim checkers -->
-            <argument /> <!-- JWS header checkers -->
-            <argument /> <!-- Mandatory claims -->
-            <argument /> <!-- Allowed signature algorithms -->
+            <argument type="collection" /> <!-- Claim checkers -->
+            <argument type="collection"/> <!-- JWS header checkers -->
+            <argument type="collection"/> <!-- Mandatory claims -->
+            <argument type="collection" /> <!-- Allowed signature algorithms -->
             <argument /> <!-- Signature keyset -->
             <argument on-invalid="null" /> <!-- Continue on decryption failure -->
-            <argument on-invalid="null" /> <!-- JWE header checkers -->
-            <argument on-invalid="null" /> <!-- Allowed key encryption algorithms -->
-            <argument on-invalid="null" /> <!-- Allowed content encryption algorithms -->
+            <argument type="collection" on-invalid="null" /> <!-- JWE header checkers -->
+            <argument type="collection" on-invalid="null" /> <!-- Allowed key encryption algorithms -->
+            <argument type="collection" on-invalid="null" /> <!-- Allowed content encryption algorithms -->
             <argument on-invalid="null" /> <!-- Encryption keyset -->
         </service>
         <service id="lexik_jwt_authentication.web_token.iat_validator" class="Jose\Component\Checker\IssuedAtChecker" public="false">


### PR DESCRIPTION
If I use the feature "webtoken" with that bundle than the following configuration (only signing jwk but not encrypting), leads to an exception when the Encoder is loader and Dependencies are injected.

```
lexik_jwt_authentication:
    public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
    encoder:
        service: lexik_jwt_authentication.encoder.web_token
    access_token_issuance:
        enabled: true
        signature:
            algorithm: EdDSA
            key: '%env(SIGNATURE_KEY)%'
    access_token_verification:
        enabled: true
        signature:
            allowed_algorithms:
                - EdDSA
            keyset: '%env(SIGNATURE_VERIFICATION_KEYSET)%'
```
The problem in my opinion is the default xml Service configuration, that does not specify the right type. If one acitvates encryption this error disappears as than this config is overwritten anyhow.


```
In AccessTokenLoader.php line 38:                                                                                                                                                                                                                                                                        
Lexik\Bundle\JWTAuthenticationBundle\Services\WebToken\AccessTokenLoader::__construct(): Argument #10 ($jweHeaderChecker) must be of type ?array, string given, called in /var/www/html/var/cache/test/Container1K8ziZx/getLexikJwtAuthentication_AccessTokenLoaderService.php on line 29 
``` 
                                                                                                                                                                                                                                       