### PR TITLE
feat: Pass DisabledException to JWTAuthenticationFailureResponse

### DIFF
--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -8,6 +8,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationFailureRespon
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -40,6 +41,10 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
+        if($exception->getPrevious() instanceof DisabledException) {
+            $exception = $exception->getPrevious();
+        }
+        
         $errorMessage = strtr($exception->getMessageKey(), $exception->getMessageData());
         $statusCode = self::mapExceptionCodeToStatusCode($exception->getCode());
         if ($this->translator) {

--- a/Security/Http/Authentication/AuthenticationFailureHandler.php
+++ b/Security/Http/Authentication/AuthenticationFailureHandler.php
@@ -41,7 +41,7 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
-        if($exception->getPrevious() instanceof DisabledException) {
+        if ($exception->getPrevious() instanceof DisabledException) {
             $exception = $exception->getPrevious();
         }
         

--- a/Tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
+++ b/Tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -39,6 +40,29 @@ class AuthenticationFailureHandlerTest extends TestCase
         $this->assertEquals(401, $content['code']);
         $this->assertEquals($authenticationException->getMessageKey(), $content['message']);
     }
+
+    /**
+     * test onAuthenticationFailure method.
+     */
+    public function testOnAuthenticationFailureWithDisabledUser()
+    {
+        $dispatcher = $this
+            ->getMockBuilder(EventDispatcherInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $authenticationException = $this->getDisabledException();
+
+        $handler = new AuthenticationFailureHandler($dispatcher);
+        $response = $handler->onAuthenticationFailure($this->getRequest(), $authenticationException);
+        $content = json_decode($response->getContent(), true);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        $this->assertEquals(401, $content['code']);
+        $this->assertEquals($authenticationException->getMessageKey(), $content['message']);
+    }
+
 
     /**
      * test onAuthenticationFailure method.
@@ -141,5 +165,13 @@ class AuthenticationFailureHandlerTest extends TestCase
     protected function getAuthenticationException()
     {
         return new AuthenticationException();
+    }
+
+    /**
+     * @return DisabledException
+     */
+    protected function getDisabledException()
+    {
+        return new DisabledException();
     }
 }


### PR DESCRIPTION
Hi,

currently the response is always "Bad credentials". If a user has been disabled, the response should be accordingly so the user can take additional steps, for example contacting the admin.

This PR checks if the AuthenticationException "previous" is a DisabledException and passes that instead.

What do you think?