### PR TITLE
[CI] Fixed CI for PHP 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     tests:
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
         continue-on-error: ${{ matrix.can-fail }}
         strategy:
             fail-fast: false
@@ -17,24 +17,29 @@ jobs:
                       symfony: 5.4.*
                       composer-flags: '--prefer-stable --prefer-lowest'
                       can-fail: false
+                      os: ubuntu-20.04
                     # LTS with latest stable PHP
                     - php: 8.3
                       symfony: 6.4.*
                       composer-flags: '--prefer-stable'
                       can-fail: false
+                      os: ubuntu-latest
                       # Stable Symfony branches
                     - php: 8.2
                       symfony: 6.3.*
                       composer-flags: '--prefer-stable'
                       can-fail: false
+                      os: ubuntu-latest
                     - php: 8.2
                       symfony: 6.4.*
                       composer-flags: '--prefer-stable'
                       can-fail: false
+                      os: ubuntu-latest
                     - php: 8.3
                       symfony: 7.0.*
                       composer-flags: '--prefer-stable'
                       can-fail: false
+                      os: ubuntu-latest
 
         name: "PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }}${{ matrix.composer-flags != '' && format(' - Composer {0}', matrix.composer-flags) || '' }}"
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": ">=7.1",
         "ext-openssl": "*",
         "lcobucci/clock": "^1.2|^2.0|^3.0",
-        "lcobucci/jwt": "^3.4|^4.1|^5.0",
+        "lcobucci/jwt": "^3.4.6|^4.1|^5.0",
         "namshi/jose": "^7.2",
         "symfony/config": "^4.4|^5.4|^6.0|^7.0",
         "symfony/dependency-injection": "^4.4|^5.4|^6.0|^7.0",
@@ -58,7 +58,7 @@
         "symfony/dom-crawler": "^5.4|^6.0|^7.0",
         "symfony/filesystem": "^4.4|^5.4|^6.0|^7.0",
         "symfony/framework-bundle": "^4.4|^5.4|^6.0|^7.0",
-        "symfony/phpunit-bridge": "^4.4|^5.4|^6.0|^7.0",
+        "symfony/phpunit-bridge": "^7.0.1",
         "symfony/security-guard": "^4.4|^5.4|^6.0|^7.0",
         "symfony/var-dumper": "^4.4|^5.4|^6.0|^7.0",
         "symfony/yaml": "^4.4|^5.4|^6.0|^7.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,7 +28,7 @@
     </filter>
 
     <php>
-        <env name="SYMFONY_PHPUNIT_VERSION" value="9.5"></env>
+        <env name="SYMFONY_MAX_PHPUNIT_VERSION" value="9.5"></env>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=27"></env>
     </php>
 </phpunit>


### PR DESCRIPTION
This PR is my attempt at fixing the "always green" build for 7.2 (mentioned in https://github.com/lexik/LexikJWTAuthenticationBundle/pull/1183#issuecomment-1843291457)

Things done:
1) I've bumped the PHPUnit Bridge version to the latest one.

According to [PHPUnit Bridge doc](https://symfony.com/doc/current/components/phpunit_bridge.html#installation):
```
The PHPUnit bridge is designed to work with all maintained versions of Symfony components, even across different major versions of them. You should always use its very latest stable major version to get the most accurate deprecation report.
```

Allowing phpunit-bridge range of `"^4.4|^5.4|^6.0|^7.0"` together with `--prefer-lowest` means that the 4.4.0 version of it is installed - which doesn't have all the required bugfixes.

I've chosen ^7.0 as the latest one, for the 7.x series 7.0.1 is needed because it contains the bugfix for this issue: https://github.com/symfony/demo/pull/1457#issuecomment-1836188457

2) Set PHPUnit 9.5 as the max version

The 7.2 build cannot use PHPUnit 9.5, [it requires PHP 7.3](https://github.com/sebastianbergmann/phpunit/blob/9.5.0/composer.json#L24)

I've set this as max version instead - it will be used if possible, otherwise lower versions will be used.

3) Bumped lowest supported version of lcobucci/jwt to 3.4.6

One of the tests was failing:
```
1) Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\GetTokenTest::testGetTokenWithCustomClaim
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
     0 => 'foo'
-    1 => 'bar'
 )
```

This was fixed by bumping the version of lcobucci/jwt to 3.4.6 - I suspect it contains bugfix not present in 3.4.0

4) Run PHP 7.2 tests on ubuntu-20

I found this issue when googling: https://github.com/shivammathur/setup-php/issues/720
```
If you are running this on the ubuntu-latest or ubuntu-22.04 runner, that has OpenSSL 3 and support for it was added to PHP in 8.1. Please use ubuntu-20.04 runner with the older PHP versions and this should work.
```

And it was right, all of a sudden the segmentation faults have disappeared.

Overall I feel everything I did was a bit hacky, but the build is now green 🎉 

