### PR TITLE
Use symfony/clock component when available instead of non-testable time()

### DIFF
--- a/Command/GenerateTokenCommand.php
+++ b/Command/GenerateTokenCommand.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Command;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -81,7 +82,8 @@ class GenerateTokenCommand extends Command
         if (null !== $input->getOption('ttl') && ((int) $input->getOption('ttl')) == 0) {
             $payload['exp'] = 0;
         } elseif (null !== $input->getOption('ttl') && ((int) $input->getOption('ttl')) > 0) {
-            $payload['exp'] = time() + $input->getOption('ttl');
+            $now = Clock::get()->now()->getTimestamp();
+            $payload['exp'] = $now + $input->getOption('ttl');
         }
 
         $token = $this->tokenManager->createFromPayload($user, $payload);

--- a/Security/Http/Cookie/JWTCookieProvider.php
+++ b/Security/Http/Cookie/JWTCookieProvider.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Cookie;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Helper\JWTSplitter;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -62,7 +63,8 @@ final class JWTCookieProvider
         $jwt = $jwtParts->getParts($split ?: $this->defaultSplit);
 
         if (null === $expiresAt) {
-            $expiresAt = 0 === $this->defaultLifetime ? 0 : (time() + $this->defaultLifetime);
+            $now = Clock::get()->now()->getTimestamp();
+            $expiresAt = 0 === $this->defaultLifetime ? 0 : ($now + $this->defaultLifetime);
         }
 
         return Cookie::create(

--- a/Services/JWSProvider/LcobucciJWSProvider.php
+++ b/Services/JWSProvider/LcobucciJWSProvider.php
@@ -24,7 +24,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Services\KeyLoader\KeyLoaderInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Signature\CreatedJWS;
 use Lexik\Bundle\JWTAuthenticationBundle\Signature\LoadedJWS;
 use Psr\Clock\ClockInterface;
-use Symfony\Component\Clock\NativeClock;
+use Symfony\Component\Clock\Clock;
 
 /**
  * @final
@@ -46,7 +46,7 @@ class LcobucciJWSProvider implements JWSProviderInterface
     public function __construct(KeyLoaderInterface $keyLoader, string $signatureAlgorithm, ?int $ttl, ?int $clockSkew, bool $allowNoExpiration = false, ?ClockInterface $clock = null)
     {
         if (null === $clock) {
-            $clock = new NativeClock(new \DateTimeZone('UTC'));
+            $clock = Clock::get();
         }
 
         $this->keyLoader = $keyLoader;
@@ -68,7 +68,7 @@ class LcobucciJWSProvider implements JWSProviderInterface
             $jws = $jws->withHeader($k, $v);
         }
 
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
 
         $issuedAt = $payload['iat'] ?? $now;
         unset($payload['iat']);

--- a/Signature/LoadedJWS.php
+++ b/Signature/LoadedJWS.php
@@ -2,6 +2,8 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Signature;
 
+use Symfony\Component\Clock\Clock;
+
 /**
  * Object representation of a JSON Web Signature loaded from an
  * existing JSON Web Token.
@@ -74,7 +76,8 @@ final class LoadedJWS
             return;
         }
 
-        if ($this->clockSkew <= time() - $this->payload['exp']) {
+        $now = Clock::get()->now()->getTimestamp();
+        if ($this->clockSkew <= $now - $this->payload['exp']) {
             $this->state = self::EXPIRED;
         }
     }
@@ -84,7 +87,8 @@ final class LoadedJWS
      */
     private function checkIssuedAt(): void
     {
-        if (isset($this->payload['iat']) && (int) $this->payload['iat'] - $this->clockSkew > time()) {
+        $now = Clock::get()->now()->getTimestamp();
+        if (isset($this->payload['iat']) && (int) $this->payload['iat'] - $this->clockSkew > $now) {
             $this->state = self::INVALID;
         }
     }

--- a/Subscriber/AdditionalAccessTokenClaimsAndHeaderSubscriber.php
+++ b/Subscriber/AdditionalAccessTokenClaimsAndHeaderSubscriber.php
@@ -4,6 +4,7 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Subscriber;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class AdditionalAccessTokenClaimsAndHeaderSubscriber implements EventSubscriberInterface
@@ -29,14 +30,15 @@ final class AdditionalAccessTokenClaimsAndHeaderSubscriber implements EventSubsc
 
     public function addClaims(JWTCreatedEvent $event): void
     {
+        $now = Clock::get()->now()->getTimestamp();
         $claims = [
             'jti' => uniqid('', true),
-            'iat' => time(),
-            'nbf' => time(),
+            'iat' => $now,
+            'nbf' => $now,
         ];
         $data = $event->getData();
         if (!array_key_exists('exp', $data) && $this->ttl > 0) {
-            $claims['exp'] = time() + $this->ttl;
+            $claims['exp'] = $now + $this->ttl;
         }
         $event->setData(array_merge($claims, $data));
     }

--- a/Tests/Signature/LoadedJWSTest.php
+++ b/Tests/Signature/LoadedJWSTest.php
@@ -4,7 +4,8 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Signature;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Signature\LoadedJWS;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\MockClock;
 
 /**
  * Tests the CreatedJWS model class.
@@ -127,7 +128,7 @@ final class LoadedJWSTest extends TestCase
     {
         // 2020-10-25 00:16:13 UTC+0
         $timestamp = 1_603_584_973;
-        ClockMock::withClockMock($timestamp);
+        Clock::set(new MockClock("@$timestamp"));
 
         $dstPayload = [
             'username' => 'test',


### PR DESCRIPTION
**Motivation**:
Tests are already hard enough to build so that they are testing, covering, isolated and in an expected way.
Therefore, managing external dependencies is an obligation. And time is an external dependency.

With the introduction of [symfony/clock](https://symfony.com/components/Clock) in 6.3, Symfony proposes a solution for managing time in an application, with a shared instance that is overridable during the tests.

Now that the library requires it as a dependencies, we can use it everywhere it should be used in place of php native methods.

**Solution**:
This PR looked over the time() usage, and replaced them with Symfony's `Clock::now()->getTimeStamp()` when available.

**Retro-compatibility**:
This behavior change is probably what the user would expect from a library having symfony/clock as a requirement ; so they probably are fine.

**Tests**:
Current test suite still uses time(), but they could be improved to take advantage of this new testability.