### PR TITLE
Remove security for `/auth` route in OpenAPI generator

### DIFF
--- a/OpenApi/OpenApiFactory.php
+++ b/OpenApi/OpenApiFactory.php
@@ -91,6 +91,7 @@ class OpenApiFactory implements OpenApiFactoryInterface
                     ]))
                     ->withRequired(true)
                 )
+                ->withSecurity([])
             ));
 
         return $openApi;

--- a/Tests/Functional/Command/ApiPlatformOpenApiExportCommandTest.php
+++ b/Tests/Functional/Command/ApiPlatformOpenApiExportCommandTest.php
@@ -106,9 +106,9 @@ class ApiPlatformOpenApiExportCommandTest extends TestCase
         "description": "Creates a user token.",
         "tags": [
           "Login Check"
-        ]
+        ],
+        "security": []
       },
-      "security": [],
       "parameters": []
     }
   },

--- a/Tests/Functional/Command/ApiPlatformOpenApiExportCommandTest.php
+++ b/Tests/Functional/Command/ApiPlatformOpenApiExportCommandTest.php
@@ -108,6 +108,7 @@ class ApiPlatformOpenApiExportCommandTest extends TestCase
           "Login Check"
         ]
       },
+      "security": [],
       "parameters": []
     }
   },


### PR DESCRIPTION
The `/auth` route is always public, so we can disabled the security part in OpenAPI.