### PR TITLE
Fix default values in WebToken services when encryption disabled

### DIFF
--- a/Resources/config/web_token_issuance.xml
+++ b/Resources/config/web_token_issuance.xml
@@ -11,9 +11,9 @@
             <argument type="service" id="Jose\Bundle\JoseFramework\Services\JWEBuilderFactory" on-invalid="null" />
             <argument /> <!-- Signature algorithm -->
             <argument /> <!-- Signature key -->
-            <argument /> <!-- Key encryption algorithm -->
-            <argument /> <!-- Content encryption algorithm -->
-            <argument /> <!-- Encryption key -->
+            <argument>null</argument> <!-- Key encryption algorithm -->
+            <argument>null</argument> <!-- Content encryption algorithm -->
+            <argument>null</argument> <!-- Encryption key -->
         </service>
     </services>
 </container>

--- a/Resources/config/web_token_verification.xml
+++ b/Resources/config/web_token_verification.xml
@@ -10,15 +10,15 @@
             <argument type="service" id="Jose\Bundle\JoseFramework\Services\JWELoaderFactory" on-invalid="null" />
             <argument type="service" id="Jose\Bundle\JoseFramework\Services\ClaimCheckerManagerFactory" />
             <argument type="collection" /> <!-- Claim checkers -->
-            <argument type="collection"/> <!-- JWS header checkers -->
-            <argument type="collection"/> <!-- Mandatory claims -->
+            <argument type="collection" /> <!-- JWS header checkers -->
+            <argument type="collection" /> <!-- Mandatory claims -->
             <argument type="collection" /> <!-- Allowed signature algorithms -->
             <argument /> <!-- Signature keyset -->
-            <argument on-invalid="null" /> <!-- Continue on decryption failure -->
+            <argument>false</argument> <!-- Continue on decryption failure -->
             <argument type="collection" /> <!-- JWE header checkers -->
             <argument type="collection" /> <!-- Allowed key encryption algorithms -->
             <argument type="collection" /> <!-- Allowed content encryption algorithms -->
-            <argument on-invalid="null" /> <!-- Encryption keyset -->
+            <argument>null</argument> <!-- Encryption keyset -->
         </service>
         <service id="lexik_jwt_authentication.web_token.iat_validator" class="Jose\Component\Checker\IssuedAtChecker" public="false">
             <argument>%lexik_jwt_authentication.clock_skew%</argument>

--- a/Services/WebToken/AccessTokenLoader.php
+++ b/Services/WebToken/AccessTokenLoader.php
@@ -46,7 +46,7 @@ final class AccessTokenLoader
         ?string                     $encryptionKeyset
     ) {
         $this->jwsLoader = $jwsLoaderFactory->create(['jws_compact'], $signatureAlgorithms, $jwsHeaderChecker);
-        if ($jweLoaderFactory !== null && $keyEncryptionAlgorithms !== null && $contentEncryptionAlgorithms !== null && $jweHeaderChecker !== null) {
+        if ($jweLoaderFactory !== null && !empty($keyEncryptionAlgorithms) && !empty($contentEncryptionAlgorithms) && !empty($jweHeaderChecker)) {
             $this->jweLoader = $jweLoaderFactory->create(['jwe_compact'], array_merge($keyEncryptionAlgorithms, $contentEncryptionAlgorithms), null, null, $jweHeaderChecker);
             $this->continueOnDecryptionFailure = $continueOnDecryptionFailure;
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Symfony Version | 6.4.x
| Bundle Version | 3.0.0
| PHP Version | 8.2
| Fixed Tickets | fixes #1223 
| Related Issues/PRs | #1209, #1214 

This PR fixes the default values in the `AccessTokenBuilder` and `AccessTokenLoader` services when encryption is disabled.