### PR TITLE
Ignore token not having the getCredentials() method during decode

### DIFF
--- a/Services/JWTManager.php
+++ b/Services/JWTManager.php
@@ -10,6 +10,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTEncodedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTEncodeFailureException;
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\Token\JWTPostAuthenticationToken;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\PayloadEnrichment\NullEnrichment;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -98,6 +99,16 @@ class JWTManager implements JWTTokenManagerInterface
      */
     public function decode(TokenInterface $token): array|bool
     {
+        if (!$token instanceof JWTPostAuthenticationToken) {
+            /*
+             * TokenInterface::getCredentials() was deprecated in Symfony 5.4 and removed in Symfony 6.
+             * Because tokens should no longer contain credentials (as they represent authenticated sessions).
+             * https://github.com/symfony/symfony/commit/922c1314bd73f14fb8aa80e62b27b3bca66ee7b0#diff-24aa6aa94d3f4a8aed52d78f81f217b60fd69dccb575357844c1250a61153a34
+             */
+            @trigger_deprecation("lexik/jwt-authentication-bundle", "3.2", "Not passing a JWTPostAuthenticationToken to JWTManager::decode() is deprecated");
+
+            return false;
+        }
         if (!($payload = $this->jwtEncoder->decode($token->getCredentials()))) {
             return false;
         }

--- a/Tests/Services/JWTManagerTest.php
+++ b/Tests/Services/JWTManagerTest.php
@@ -12,6 +12,8 @@ use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\PayloadEnrichmentInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\TestBrowserToken;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -135,6 +137,56 @@ class JWTManagerTest extends TestCase
 
         $manager = new JWTManager($encoder, $dispatcher, 'username');
         $this->assertSame(['foo' => 'bar'], $manager->decode($this->getJWTUserTokenMock()));
+    }
+
+    /**
+     * test decode a TokenInterface without getCredentials.
+     */
+    public function testDecode_noGetCredentials()
+    {
+        $dispatcher = $this->getEventDispatcherMock();
+        $dispatcher
+            ->expects($this->never())
+            ->method('dispatch')
+            ->with(
+                $this->isInstanceOf(JWTDecodedEvent::class),
+                $this->equalTo(Events::JWT_DECODED)
+            );
+
+        $encoder = $this->getJWTEncoderMock();
+        $encoder
+            ->expects($this->never())
+            ->method('decode')
+            ->willReturn(['foo' => 'bar']);
+
+        $token = new NullToken();
+        $manager = new JWTManager($encoder, $dispatcher, 'username');
+        $this->assertFalse($manager->decode($token));
+    }
+
+    /**
+     * test decode a TokenInterface with getCredentials returning null.
+     */
+    public function testDecode_nullGetCredentials()
+    {
+        $dispatcher = $this->getEventDispatcherMock();
+        $dispatcher
+            ->expects($this->never())
+            ->method('dispatch')
+            ->with(
+                $this->isInstanceOf(JWTDecodedEvent::class),
+                $this->equalTo(Events::JWT_DECODED)
+            );
+
+        $encoder = $this->getJWTEncoderMock();
+        $encoder
+            ->expects($this->never())
+            ->method('decode')
+            ->willReturn(['foo' => 'bar']);
+
+        $token = new TestBrowserToken();
+        $manager = new JWTManager($encoder, $dispatcher, 'username');
+        $this->assertFalse($manager->decode($token));
     }
 
     public function testParse()


### PR DESCRIPTION
The `getCredentials()` method  was removed from `TokenInterface` in Symfony 6. Beside, some tokens, such as `TestBrowserToken`, return null instead of the expected string type. See [issue #1040](https://github.com/lexik/LexikJWTAuthenticationBundle/issues/1040).

Decoding a jwt token is only meaningful when the token is a `JWTPostAuthenticationToken`. Any other token can be ignored.

To fix the deprecation, the user's code must do something like this:

```php
if (!$token instanceof JWTPostAuthenticationToken) {
    return;
}
try {
    $jwtPayload = $this->jwtManager->decode($token);
} catch (JWTDecodeFailureException) {
    return;
}
if ($jwtPayload === false) {
    return;
}
// process $jwtPayload…    
```

Now, the questions:

1. Do we deprecate the call with anything other than a `JWTPostAuthenticationToken` with the aim of restricting the type to `public function decode(JWTPostAuthenticationToken $token): array|bool` later on?
2. Do we simply ignore tokens other than `JWTPostAuthenticationToken` without deprecation to make the use of the decode method easier?

This PR is currently aiming at the first solution but solution 2 simply requires to remove the `trigger_deprecation` call.