### PR TITLE
[docs] Add user_id_claim to Full default configuration in 1-configuration-reference.rst

### DIFF
--- a/Resources/doc/1-configuration-reference.rst
+++ b/Resources/doc/1-configuration-reference.rst
@@ -46,6 +46,7 @@ Full default configuration
         public_key: ~
         pass_phrase: ~
         token_ttl: 3600 # token TTL in seconds, defaults to 1 hour
+        user_id_claim: username
         clock_skew: 0
         allow_no_expiration: false # set to true to allow tokens without exp claim
 


### PR DESCRIPTION
I made a small change in the Resources/doc/1-configuration-reference.rst file by adding user_id_claim along with its default value to the 'Full default configuration' section, to make it consistent with the 2.x version of the documentation. People probably had trouble finding this attribute name because it wasn't documented, so they had to debug or look into the source code to find it.