### PR TITLE
Remove trailing whitespace from LexikJWTAuthenticationExtension.php

### DIFF
--- a/DependencyInjection/LexikJWTAuthenticationExtension.php
+++ b/DependencyInjection/LexikJWTAuthenticationExtension.php
@@ -96,7 +96,7 @@ class LexikJWTAuthenticationExtension extends Extension
                 if ($attributes['partitioned'] && Kernel::VERSION < '6.4') {
                     throw new \LogicException(sprintf('The `partitioned` option for cookies is only available for Symfony 6.4 and above. You are currently on version %s', Kernel::VERSION));
                 }
-                
+
                 $container
                     ->setDefinition($id = "lexik_jwt_authentication.cookie_provider.$name", new ChildDefinition('lexik_jwt_authentication.cookie_provider'))
                     ->replaceArgument(0, $name)


### PR DESCRIPTION
This is the single line in all the project's php files containing trailing white-space.