### PR TITLE
Improve JWTUser phpdoc

### DIFF
--- a/Security/User/JWTUser.php
+++ b/Security/User/JWTUser.php
@@ -11,9 +11,15 @@ namespace Lexik\Bundle\JWTAuthenticationBundle\Security\User;
  */
 class JWTUser implements JWTUserInterface
 {
+    /** @var non-empty-string */
     private string $userIdentifier;
+    /** @var string[] */
     private array $roles;
 
+    /**
+     * @param non-empty-string $userIdentifier
+     * @param string[]         $roles
+     */
     public function __construct(string $userIdentifier, array $roles = [])
     {
         $this->userIdentifier = $userIdentifier;

--- a/Security/User/JWTUserInterface.php
+++ b/Security/User/JWTUserInterface.php
@@ -9,7 +9,7 @@ interface JWTUserInterface extends UserInterface
     /**
      * Creates a new instance from a given JWT payload.
      *
-     * @param string $username
+     * @param non-empty-string $username
      *
      * @return JWTUserInterface
      */


### PR DESCRIPTION
Hi @chalasr,

Since https://github.com/symfony/symfony/pull/58007 the `getUserIdentifier` method is supposed to return a non-empty-string, which means that
- JWTUser should only accepts non-empty-string in the constructor
- createFromPayload should only accepts non-empty-string