### PR TITLE
Allow to pass extra data when handling success authentication

### DIFF
--- a/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -48,7 +48,7 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
         return $this->handleAuthenticationSuccess($token->getUser());
     }
 
-    public function handleAuthenticationSuccess(UserInterface $user, $jwt = null): Response
+    public function handleAuthenticationSuccess(UserInterface $user, $jwt = null, array $data = []): Response
     {
         if (null === $jwt) {
             $jwt = $this->jwtManager->create($user);
@@ -59,8 +59,8 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
             $jwtCookies[] = $cookieProvider->createCookie($jwt);
         }
 
-        $response = new JWTAuthenticationSuccessResponse($jwt, [], $jwtCookies);
-        $event = new AuthenticationSuccessEvent(['token' => $jwt], $user, $response);
+        $response = new JWTAuthenticationSuccessResponse($jwt, $data, $jwtCookies);
+        $event = new AuthenticationSuccessEvent(['token' => $jwt] + $data, $user, $response);
 
         $this->dispatcher->dispatch($event, Events::AUTHENTICATION_SUCCESS);
         $responseData = $event->getData();

--- a/Tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/Tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
@@ -69,6 +69,21 @@ class AuthenticationSuccessHandlerTest extends TestCase
         $this->assertSame('jwt', $content['token']);
     }
 
+    public function testHandleAuthenticationSuccessWithExtraData()
+    {
+        $response = (new AuthenticationSuccessHandler($this->getJWTManager('secrettoken'), $this->getDispatcher()))
+            ->handleAuthenticationSuccess($this->getUser(), null, ['state' => 'foo']);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+
+        $content = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('token', $content);
+        $this->assertSame('secrettoken', $content['token']);
+        $this->assertArrayHasKey('state', $content);
+        $this->assertSame('foo', $content['state']);
+    }
+
     public function testOnAuthenticationSuccessSetCookie()
     {
         $request = $this->getRequest();


### PR DESCRIPTION
Hi @chalasr, 

I have a use case when I'd like to return an extra data in the response of the authentication, basically a user "state" (in context of SSO to tell if the user was created or already exists).

In my service I already do my work and then call
```
$this->authenticationSuccessHandler->handleAuthenticationSuccess($user)
```
manually.

Unfortunately I cannot pass aditionnal data this way. Listening the `Events::AUTHENTICATION_SUCCESS` event to modify the data is not a solution, since the listener won't have the information i want to add to the event data.

The best solution I see is, in the same way it's currently possible to pass a specific jwt, to allow passing extra data on the handleAuthenticationSuccess method.

I try to implement it ; WDYT ?