### PR TITLE
ci: Add testruns for PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           - php: 8.4
             symfony: 8.0.*
             can-fail: false
+          - php: 8.5
+            symfony: 8.0.*
+            can-fail: false
 
     name: "PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }}${{ matrix.composer-flags != '' && format(' - Composer {0}', matrix.composer-flags) || '' }}"
 

--- a/OpenApi/OpenApiFactory.php
+++ b/OpenApi/OpenApiFactory.php
@@ -83,11 +83,11 @@ class OpenApiFactory implements OpenApiFactoryInterface
                     (new RequestBody())
                     ->withDescription('The login data')
                     ->withContent(new \ArrayObject([
-                        'application/json' => new MediaType(new \ArrayObject(new \ArrayObject([
+                        'application/json' => new MediaType(new \ArrayObject([
                             'type' => 'object',
                             'properties' => $properties = array_merge_recursive($this->getJsonSchemaFromPathParts(explode('.', $this->usernamePath)), $this->getJsonSchemaFromPathParts(explode('.', $this->passwordPath))),
                             'required' => array_keys($properties),
-                        ]))),
+                        ])),
                     ]))
                     ->withRequired(true)
                 )

--- a/Tests/Functional/CompleteTokenAuthenticationTest.php
+++ b/Tests/Functional/CompleteTokenAuthenticationTest.php
@@ -96,7 +96,10 @@ class CompleteTokenAuthenticationTest extends TestCase
         $idClaim = static::$kernel->getContainer()->getParameter('lexik_jwt_authentication.user_id_claim');
 
         $r = new \ReflectionProperty($encoder !== null ? get_class($encoder) : self::class, 'jwsProvider');
-        $r->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $r->setAccessible(true);
+        }
+
         $jwsProvider = $r->getValue($encoder);
         \Closure::bind(function () {
             $this->ttl = null;


### PR DESCRIPTION
Update: Fixed the deprecation. But needs a closer look if it was done correct.

```
Remaining self deprecation notices (1)
  1x: ArrayObject::__construct(): Using an object as a backing array for ArrayObject is deprecated, as it allows violating class constraints and invariants
    1x in ApiPlatformOpenApiExportCommandTest::testCheckOpenApiExportCommand from Lexik\Bundle\JWTAuthenticationBundle\Tests\Functional\Command
```
https://github.com/php/php-src/blob/fb87b14b6cb7a3895fb327062805a4a22c4dd909/ext/spl/tests/ArrayObject/gh15918.phpt