### PR TITLE
fix: JWTUserProvider stale user cache in long-running runtimes

### DIFF
--- a/Resources/config/token_extractor.php
+++ b/Resources/config/token_extractor.php
@@ -40,6 +40,7 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('lexik_jwt_authentication.security.jwt_user_provider', JWTUserProvider::class)
         ->private()
+        ->tag('kernel.reset', ['method' => 'reset'])
         ->args([
             '',
         ]);

--- a/Security/User/JWTUserProvider.php
+++ b/Security/User/JWTUserProvider.php
@@ -3,13 +3,14 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Security\User;
 
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * JWT User provider.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-final class JWTUserProvider implements PayloadAwareUserProviderInterface
+final class JWTUserProvider implements PayloadAwareUserProviderInterface, ResetInterface
 {
     private string $class;
 
@@ -64,5 +65,10 @@ final class JWTUserProvider implements PayloadAwareUserProviderInterface
     public function refreshUser(UserInterface $user): UserInterface
     {
         return $user; // noop
+    }
+
+    public function reset(): void
+    {
+        $this->cache = [];
     }
 }


### PR DESCRIPTION
In long-running PHP runtimes (FrankenPHP, RoadRunner, Swoole), the DI container persists across requests, causing JWTUserProvider's in-memory cache to accumulate stale user objects. A user authenticating with a new JWT carrying different roles would receive the cached user from a prior request, leading to incorrect role assignment.

Implement ResetInterface on JWTUserProvider and tag the service with kernel.reset so that Symfony's ServicesResetter clears the cache between requests. The tag is required because the service is registered manually without autoconfigure.

Fixes #1307