### PR TITLE
Add support for AttributesBasedUserProviderInterface

### DIFF
--- a/Security/Authenticator/JWTAuthenticator.php
+++ b/Security/Authenticator/JWTAuthenticator.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\AttributesBasedUserProviderInterface;
 use Symfony\Component\Security\Core\User\ChainUserProvider;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -182,14 +183,24 @@ class JWTAuthenticator extends AbstractAuthenticator implements AuthenticationEn
      */
     protected function loadUser(array $payload, string $identity): UserInterface
     {
+        if ($this->userProvider instanceof AttributesBasedUserProviderInterface) {
+            return $this->userProvider->loadUserByIdentifier($identity, $payload);
+        }
         if ($this->userProvider instanceof PayloadAwareUserProviderInterface) {
+            trigger_deprecation('lexik/jwt-authentication-bundle', '3.3', 'Implementing %s is deprecated, implements %s instead.', PayloadAwareUserProviderInterface::class, AttributesBasedUserProviderInterface::class);
+
             return $this->userProvider->loadUserByIdentifierAndPayload($identity, $payload);
         }
 
         if ($this->userProvider instanceof ChainUserProvider) {
             foreach ($this->userProvider->getProviders() as $provider) {
                 try {
+                    if ($provider instanceof AttributesBasedUserProviderInterface) {
+                        return $provider->loadUserByIdentifier($identity, $payload);
+                    }
                     if ($provider instanceof PayloadAwareUserProviderInterface) {
+                        trigger_deprecation('lexik/jwt-authentication-bundle', '3.3', 'Implementing %s is deprecated, implements %s instead.', PayloadAwareUserProviderInterface::class, AttributesBasedUserProviderInterface::class);
+
                         return $provider->loadUserByIdentifierAndPayload($identity, $payload);
                     }
 

--- a/Security/User/JWTUserProvider.php
+++ b/Security/User/JWTUserProvider.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\JWTAuthenticationBundle\Security\User;
 
+use Symfony\Component\Security\Core\User\AttributesBasedUserProviderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -10,7 +11,7 @@ use Symfony\Contracts\Service\ResetInterface;
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-final class JWTUserProvider implements PayloadAwareUserProviderInterface, ResetInterface
+final class JWTUserProvider implements AttributesBasedUserProviderInterface, PayloadAwareUserProviderInterface, ResetInterface
 {
     private string $class;
 
@@ -36,11 +37,11 @@ final class JWTUserProvider implements PayloadAwareUserProviderInterface, ResetI
     /**
      * {@inheritdoc}
      *
-     * @param array $payload The JWT payload from which to create an instance
+     * @param array $attributes The JWT payload from which to create an instance
      */
-    public function loadUserByIdentifier(string $identifier, array $payload = []): UserInterface
+    public function loadUserByIdentifier(string $identifier, array $attributes = []): UserInterface
     {
-        return $this->loadUserByIdentifierAndPayload($identifier, $payload);
+        return $this->loadUserByIdentifierAndPayload($identifier, $attributes);
     }
 
     public function loadUserByIdentifierAndPayload(string $identifier, array $payload): UserInterface

--- a/Security/User/PayloadAwareUserProviderInterface.php
+++ b/Security/User/PayloadAwareUserProviderInterface.php
@@ -12,6 +12,8 @@ interface PayloadAwareUserProviderInterface extends UserProviderInterface
      * Loads a user from an identifier and JWT token payload.
      *
      * @throws UserNotFoundException if the user is not found
+     *
+     * @deprecated use Symfony\Component\Security\Core\User\AttributesBasedUserProviderInterface instead.
      */
     public function loadUserByIdentifierAndPayload(string $identifier, array $payload): UserInterface;
 }

--- a/Tests/Security/Authenticator/JWTAuthenticatorTest.php
+++ b/Tests/Security/Authenticator/JWTAuthenticatorTest.php
@@ -22,6 +22,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\AttributesBasedUserProviderInterface;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -31,6 +32,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class JWTAuthenticatorTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testAuthenticate()
     {
         $userIdClaim = 'sub';
@@ -61,6 +65,39 @@ class JWTAuthenticatorTest extends TestCase
         $this->assertSame($userStub, ($authenticator->authenticate($this->getRequestMock()))->getUser());
     }
 
+    public function testAuthenticateWithAttributesBasedUserProvider()
+    {
+        $userIdClaim = 'sub';
+        $payload = [$userIdClaim => 'lexik'];
+        $rawToken = 'token';
+        $userRoles = ['ROLE_USER'];
+
+        $userStub = new InMemoryUser('lexik', 'password', $userRoles);
+
+        $jwtManager = $this->getJWTManagerMock($userIdClaim);
+        $jwtManager
+            ->method('parse')
+            ->willReturn(['sub' => 'lexik']);
+
+        $userProvider = $this->getAttributesBasedUserProviderMock();
+        $userProvider
+            ->method('loadUserByIdentifier')
+            ->with($payload['sub'], $payload)
+            ->willReturn($userStub);
+
+        $authenticator = new JWTAuthenticator(
+            $jwtManager,
+            $this->getEventDispatcherMock(),
+            $this->getTokenExtractorMock($rawToken),
+            $userProvider
+        );
+
+        $this->assertSame($userStub, ($authenticator->authenticate($this->getRequestMock()))->getUser());
+    }
+
+    /**
+     * @group legacy
+     */
     public function testAuthenticateWithIntegerIdentifier()
     {
         $userIdClaim = 'sub';
@@ -171,6 +208,9 @@ class JWTAuthenticatorTest extends TestCase
         $authenticator->authenticate($this->getRequestMock());
     }
 
+    /**
+     * @group legacy
+     */
     public function testAuthenticateWithInvalidUserThrowsException()
     {
         $jwtManager = $this->getJWTManagerMock();
@@ -353,6 +393,11 @@ class JWTAuthenticatorTest extends TestCase
         return $this->createMock(DummyUserProvider::class);
     }
 
+    private function getAttributesBasedUserProviderMock()
+    {
+        return $this->createMock(DummyAttributesBasedUserProvider::class);
+    }
+
     private function getTranslatorMock()
     {
         return $this->createMock(TranslatorInterface::class);
@@ -375,6 +420,17 @@ abstract class DummyUserProvider implements UserProviderInterface, PayloadAwareU
     }
 
     public function loadUserByIdentifierAndPayload(string $identifier, array $payload): UserInterface
+    {
+    }
+}
+
+abstract class DummyAttributesBasedUserProvider implements AttributesBasedUserProviderInterface
+{
+    public function loadUserByUsername(string $username): UserInterface
+    {
+    }
+
+    public function loadUserByIdentifier(string $identifier, array $attributes = []): UserInterface
     {
     }
 }


### PR DESCRIPTION
Hi @chalasr 

Symfony provides a AttributesBasedUserProviderInterface
https://github.com/symfony/security-core/blob/a8239abe61dafdd0c01c0b4019138b2855717f97/User/AttributesBasedUserProviderInterface.php#L24
 which seems similar to the existing PayloadAwareUserProviderInterface of the bundle, with the benefit that Symfony has custom check for AttributesBasedUserProviderInterface in his own code base.
 
 So I think that
- This bundle should support AttributesBasedUserProviderInterface the same way than PayloadAwareUserProviderInterface
- Maybe deprecate PayloadAwareUserProviderInterface in favor of AttributesBasedUserProviderInterface