### PR TITLE
feat: add EdDSA (Ed25519) algorithm support

### DIFF
--- a/Command/GenerateKeyPairCommand.php
+++ b/Command/GenerateKeyPairCommand.php
@@ -29,6 +29,7 @@ final class GenerateKeyPairCommand extends Command
         'ES256',
         'ES384',
         'ES512',
+        'EdDSA',
     ];
 
     private Filesystem $filesystem;
@@ -136,6 +137,10 @@ final class GenerateKeyPairCommand extends Command
 
     private function generateKeyPair(?string $passphrase): array
     {
+        if ('EdDSA' === $this->algorithm) {
+            return $this->generateEdDSAKeyPair();
+        }
+
         $config = $this->buildOpenSSLConfiguration();
 
         $resource = \openssl_pkey_new($config);
@@ -158,6 +163,20 @@ final class GenerateKeyPairCommand extends Command
         $publicKey = $publicKeyData['key'];
 
         return [$privateKey, $publicKey];
+    }
+
+    private function generateEdDSAKeyPair(): array
+    {
+        if (!\function_exists('sodium_crypto_sign_keypair')) {
+            throw new \RuntimeException('The "sodium" PHP extension is required to generate EdDSA key pairs.');
+        }
+
+        $keypair = \sodium_crypto_sign_keypair();
+
+        return [
+            \base64_encode(\sodium_crypto_sign_secretkey($keypair)),
+            \base64_encode(\sodium_crypto_sign_publickey($keypair)),
+        ];
     }
 
     private function buildOpenSSLConfiguration(): array

--- a/Resources/doc/1-configuration-reference.rst
+++ b/Resources/doc/1-configuration-reference.rst
@@ -24,6 +24,29 @@ Using RSA/ECDSA
             - '%kernel.project_dir%/config/jwt/public2.pem'
             - '%kernel.project_dir%/config/jwt/public3.pem'
 
+Using EdDSA (Ed25519)
+~~~~~~~~~~~~~~~~~~~~~
+
+Requires the ``ext-sodium`` PHP extension (bundled since PHP 7.2).
+
+Generate a keypair:
+
+.. code-block:: terminal
+
+    $ php bin/console lexik:jwt:generate-keypair
+
+EdDSA keys are stored as base64-encoded raw bytes (not PEM), so ``pass_phrase`` has no effect.
+
+.. code-block:: yaml
+
+    # config/packages/lexik_jwt_authentication.yaml
+    #...
+    lexik_jwt_authentication:
+        secret_key: '%kernel.project_dir%/config/jwt/private.pem' # base64-encoded Ed25519 secretkey
+        public_key: '%kernel.project_dir%/config/jwt/public.pem'  # base64-encoded Ed25519 publickey
+        encoder:
+            signature_algorithm: EdDSA
+
 Using HMAC
 ~~~~~~~~~~
 

--- a/Services/JWSProvider/LcobucciJWSProvider.php
+++ b/Services/JWSProvider/LcobucciJWSProvider.php
@@ -7,6 +7,7 @@ use Lcobucci\JWT\Encoding\ChainedFormatter;
 use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Ecdsa;
+use Lcobucci\JWT\Signer\Eddsa;
 use Lcobucci\JWT\Signer\Hmac;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 use Lcobucci\JWT\Signer\Hmac\Sha384;
@@ -137,6 +138,7 @@ class LcobucciJWSProvider implements JWSProviderInterface
             'ES256' => Signer\Ecdsa\Sha256::class,
             'ES384' => Signer\Ecdsa\Sha384::class,
             'ES512' => Signer\Ecdsa\Sha512::class,
+            'EdDSA' => Eddsa::class,
         ];
 
         if (!isset($signerMap[$signatureAlgorithm])) {
@@ -154,7 +156,11 @@ class LcobucciJWSProvider implements JWSProviderInterface
 
     private function getSignedToken(Builder $jws): string
     {
-        $key = InMemory::plainText($this->keyLoader->loadKey(KeyLoaderInterface::TYPE_PRIVATE), $this->signer instanceof Hmac ? '' : (string) $this->keyLoader->getPassphrase());
+        $privateKeyContent = $this->keyLoader->loadKey(KeyLoaderInterface::TYPE_PRIVATE);
+
+        $key = $this->signer instanceof Eddsa
+            ? InMemory::base64Encoded($privateKeyContent)
+            : InMemory::plainText($privateKeyContent, $this->signer instanceof Hmac ? '' : (string) $this->keyLoader->getPassphrase());
 
         $token = $jws->getToken($this->signer, $key);
 
@@ -163,7 +169,14 @@ class LcobucciJWSProvider implements JWSProviderInterface
 
     private function verify(Token $jwt): bool
     {
-        $key = InMemory::plainText($this->signer instanceof Hmac ? $this->keyLoader->loadKey(KeyLoaderInterface::TYPE_PRIVATE) : $this->keyLoader->loadKey(KeyLoaderInterface::TYPE_PUBLIC));
+        if ($this->signer instanceof Eddsa) {
+            $key = InMemory::base64Encoded($this->keyLoader->loadKey(KeyLoaderInterface::TYPE_PUBLIC));
+        } elseif ($this->signer instanceof Hmac) {
+            $key = InMemory::plainText($this->keyLoader->loadKey(KeyLoaderInterface::TYPE_PRIVATE));
+        } else {
+            $key = InMemory::plainText($this->keyLoader->loadKey(KeyLoaderInterface::TYPE_PUBLIC));
+        }
+
         $validator = new Validator();
 
         $isValid = $validator->validate(
@@ -178,11 +191,15 @@ class LcobucciJWSProvider implements JWSProviderInterface
         }
 
         // If the key used to verify the token is invalid, and it's not Hmac algorithm, try with additional public keys
-        foreach ($publicKeys as $key) {
+        foreach ($publicKeys as $rawKey) {
+            $additionalKey = $this->signer instanceof Eddsa
+                ? InMemory::base64Encoded($rawKey)
+                : InMemory::plainText($rawKey);
+
             $isValid = $validator->validate(
                 $jwt,
                 new LooseValidAt($this->clock, new \DateInterval("PT{$this->clockSkew}S")),
-                new SignedWith($this->signer, InMemory::plainText($key))
+                new SignedWith($this->signer, $additionalKey)
             );
 
             if ($isValid) {

--- a/Services/KeyLoader/RawKeyLoader.php
+++ b/Services/KeyLoader/RawKeyLoader.php
@@ -40,7 +40,13 @@ class RawKeyLoader extends AbstractKeyLoader implements KeyDumperInterface
 
         $signingKey = $this->getSigningKey();
 
-        // no public key provided, compute it from signing key
+        // Detect EdDSA key: base64-encoded sodium secretkey is exactly SODIUM_CRYPTO_SIGN_SECRETKEYBYTES when decoded
+        $decoded = base64_decode($signingKey, true);
+        if (false !== $decoded && strlen($decoded) === SODIUM_CRYPTO_SIGN_SECRETKEYBYTES) {
+            return base64_encode(sodium_crypto_sign_publickey_from_secretkey($decoded));
+        }
+
+        // no public key provided, compute it from signing key using OpenSSL
         try {
             $publicKey = openssl_pkey_get_details(openssl_pkey_get_private($signingKey, $this->getPassphrase()))['key'];
         } catch (\Throwable $e) {

--- a/Tests/Functional/Command/GenerateKeyPairCommandTest.php
+++ b/Tests/Functional/Command/GenerateKeyPairCommandTest.php
@@ -81,6 +81,47 @@ class GenerateKeyPairCommandTest extends TestCase
         yield ['ES512', 'dummy'];
     }
 
+    public function testItGeneratesEdDSAKeyPair(): void
+    {
+        $privateKeyFile = \tempnam(\sys_get_temp_dir(), 'private_');
+        $publicKeyFile = \tempnam(\sys_get_temp_dir(), 'public_');
+
+        \unlink($privateKeyFile);
+        \unlink($publicKeyFile);
+
+        $tester = new CommandTester(
+            new GenerateKeyPairCommand(
+                new Filesystem(),
+                $privateKeyFile,
+                $publicKeyFile,
+                null,
+                'EdDSA'
+            )
+        );
+
+        $returnCode = $tester->execute([], ['interactive' => false]);
+        $this->assertSame(0, $returnCode);
+        $this->assertStringContainsString('Done!', $tester->getDisplay(true));
+
+        $privateKey = \file_get_contents($privateKeyFile);
+        $publicKey = \file_get_contents($publicKeyFile);
+
+        $this->assertNotFalse($privateKey);
+        $this->assertNotFalse($publicKey);
+
+        // EdDSA keys are base64-encoded raw sodium bytes
+        $decodedPrivate = base64_decode($privateKey, true);
+        $decodedPublic = base64_decode($publicKey, true);
+
+        $this->assertNotFalse($decodedPrivate);
+        $this->assertNotFalse($decodedPublic);
+        $this->assertSame(SODIUM_CRYPTO_SIGN_SECRETKEYBYTES, \strlen($decodedPrivate));
+        $this->assertSame(SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES, \strlen($decodedPublic));
+
+        \unlink($privateKeyFile);
+        \unlink($publicKeyFile);
+    }
+
     public function testOverwriteAndSkipCannotBeCombined()
     {
         $privateKeyFile = \tempnam(\sys_get_temp_dir(), 'private_');

--- a/Tests/Services/JWSProvider/LcobucciJWSProviderTest.php
+++ b/Tests/Services/JWSProvider/LcobucciJWSProviderTest.php
@@ -155,6 +155,34 @@ EOF
         return $jwsProvider->create($payload)->getToken();
     }
 
+    public function testCreateAndVerifyWithEdDSA(): void
+    {
+        $keypair = sodium_crypto_sign_keypair();
+        $privateKey = base64_encode(sodium_crypto_sign_secretkey($keypair));
+        $publicKey = base64_encode(sodium_crypto_sign_publickey($keypair));
+
+        $keyLoaderMock = $this->getKeyLoaderMock();
+        $keyLoaderMock
+            ->method('loadKey')
+            ->willReturnMap([
+                ['private', $privateKey],
+                ['public', $publicKey],
+            ]);
+
+        $jwsProvider = new LcobucciJWSProvider($keyLoaderMock, 'EdDSA', 3600, 0);
+
+        $created = $jwsProvider->create(['username' => 'foo']);
+        $this->assertInstanceOf(CreatedJWS::class, $created);
+        $this->assertTrue($created->isSigned());
+
+        $loaded = $jwsProvider->load($created->getToken());
+        $this->assertTrue($loaded->isVerified());
+
+        $payload = $loaded->getPayload();
+        $this->assertArrayHasKey('username', $payload);
+        $this->assertEquals('foo', $payload['username']);
+    }
+
     public function testUnSignedToken()
     {
         $keyLoaderMock = $this->getKeyLoaderMock();


### PR DESCRIPTION
Closes #1248

Adds support for the `EdDSA` (Ed25519) algorithm using the `Signer\Eddsa` class already available in `lcobucci/jwt`.