### PR TITLE
Improve error message when incorrect passphrase is provided for priva…

### DIFF
--- a/Services/JWSProvider/LcobucciJWSProvider.php
+++ b/Services/JWSProvider/LcobucciJWSProvider.php
@@ -154,11 +154,20 @@ class LcobucciJWSProvider implements JWSProviderInterface
 
     private function getSignedToken(Builder $jws): string
     {
-        $key = InMemory::plainText($this->keyLoader->loadKey(KeyLoaderInterface::TYPE_PRIVATE), $this->signer instanceof Hmac ? '' : (string) $this->keyLoader->getPassphrase());
+        $passphrase = $this->signer instanceof Hmac ? '' : (string) $this->keyLoader->getPassphrase();
+	$privateKey = $this->keyLoader->loadKey(KeyLoaderInterface::TYPE_PRIVATE);
 
-        $token = $jws->getToken($this->signer, $key);
-
-        return $token->toString();
+	try {
+		$key = InMemory::plainText($privateKey,$passphrase);
+		$token = $jws->getToken($this->signer, $key);
+	} catch (\Throwable $e) {
+		throw new \InvalidArgumentException(
+			'Unable to sign the JWT token. Please verify that your passphrase is correct.',
+			0,
+			$e
+		);
+	}
+	return $token->toString();
     }
 
     private function verify(Token $jwt): bool

--- a/Tests/Services/JWSProvider/LcobucciJWSProviderTest.php
+++ b/Tests/Services/JWSProvider/LcobucciJWSProviderTest.php
@@ -170,4 +170,26 @@ EOF
 
         $create = $jwsProvider->create($payload);
     }
+
+    public function testCreateWithInvalidPassphraseThrowsInvalidArgumentException()
+    {
+        $keyLoaderMock = $this->getKeyLoaderMock();
+        $keyLoaderMock
+            ->expects($this->once())
+            ->method('loadKey')
+            ->with('private')
+            ->willReturn(self::$privateKey);
+        $keyLoaderMock
+            ->expects($this->once())
+            ->method('getPassphrase')
+            ->willReturn('wrong-passphrase');
+
+        $jwsProvider = new self::$providerClass($keyLoaderMock, 'RS256', 3600, 0);
+        $payload = ['username' => 'chalasr', 'iat' => time()];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to sign the JWT token. Please verify that your passphrase is correct.');
+
+        $jwsProvider->create($payload);
+    }
 }


### PR DESCRIPTION
## Problem

When an incorrect passphrase is provided for the private key, the bundle throws a generic `InvalidArgumentException` with the message:

> "An error occurred while trying to encode the JWT token. Please verify your configuration (private key/passphrase)"

The root cause (wrong passphrase) is not clearly communicated. The original exception from lcobucci/jwt contains OpenSSL internals like `bad decrypt` which are not developer-friendly.

Fixes #1262

## Solution

Wrap the signing operation in `LcobucciJWSProvider::getSignedToken()` in a try/catch block. When lcobucci throws during `InMemory::plainText()` or `getToken()`, we rethrow an `InvalidArgumentException` with a clear message pointing to the passphrase.

The `loadKey()` call is intentionally left outside the try/catch so that key-loading errors (wrong file path, unsupported format) propagate with their original messages unchanged.

## Changes

- `Services/JWSProvider/LcobucciJWSProvider.php` — wrap signing in try/catch
- `Tests/Services/JWSProvider/LcobucciJWSProviderTest.php` — add test for invalid passphrase scenario