### PR TITLE
Add #[Exclude] attribute to JWTUserInterface sample implementation

### DIFF
--- a/Resources/doc/8-jwt-user-provider.rst
+++ b/Resources/doc/8-jwt-user-provider.rst
@@ -66,6 +66,9 @@ Sample implementation
 
     namespace App\Security;
 
+    use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+    #[Exclude]
     final class User implements JWTUserInterface
     {
         // Your own logic


### PR DESCRIPTION
## Problem

Symfony 7.3 introduced resource tags which automatically register classes
in `App\Security` as services. Without the `#[Exclude]` attribute, the
`User` class implementing `JWTUserInterface` gets registered as a service,
breaking the `#[CurrentUser]` functionality.

See: https://symfony.com/blog/new-in-symfony-7-3-dependency-injection-improvements#resource-tags

Fixes #1288