### PR TITLE
Add #[\Deprecated] attribute to eraseCredentials() method

### DIFF
--- a/Security/User/JWTUser.php
+++ b/Security/User/JWTUser.php
@@ -69,9 +69,7 @@ class JWTUser implements JWTUserInterface
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    #[\Deprecated]
     public function eraseCredentials(): void
     {
     }


### PR DESCRIPTION
Symfony 7.3 deprecated UserInterface::eraseCredentials(). Adding the #[\Deprecated] attribute silences the deprecation notice.

Fixes #1279